### PR TITLE
Fix total current in CLI returning 10 times to much current

### DIFF
--- a/src/peblar/cli/__init__.py
+++ b/src/peblar/cli/__init__.py
@@ -967,7 +967,7 @@ async def meter(
             + meter_data.current_phase_2
             + meter_data.current_phase_3
         )
-        / 100,
+        / 1000,
         3,
     )
     table.add_row("Total current", f"{total_current}A")


### PR DESCRIPTION
# Proposed Changes

Total current showed 10 times too much current, this PR fixes that.

```
       Peblar meter status       
┏━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┓
┃ Property        ┃ Value       ┃
┡━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━┩
│ Energy session  │ 13.104kWh   │
│ Energy total    │ 3413.186kWh │
├─────────────────┼─────────────┤
│ Total power     │ 3365W       │
│ Power phase 1   │ 3365W       │
│ Power phase 2   │ 0W          │
│ Power phase 3   │ 0W          │
├─────────────────┼─────────────┤
│ Total current   │ 151.91A     │
│ Current Phase 1 │ 15.191A     │
│ Current Phase 2 │ 0.0A        │
│ Current Phase 3 │ 0.0A        │
├─────────────────┼─────────────┤
│ Voltage Phase 1 │ 222V        │
│ Voltage Phase 2 │ 232V        │
│ Voltage Phase 3 │ 233V        │
└─────────────────┴─────────────┘
```

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
