### PR TITLE
Handle empty string cases for source parameters

### DIFF
--- a/src/peblar/models.py
+++ b/src/peblar/models.py
@@ -409,9 +409,9 @@ class PeblarUserConfiguration(BaseModel):
     def __pre_deserialize__(cls, d: dict[Any, Any]) -> dict[Any, Any]:
         """Pre deserialize hook for PeblarUserConfiguration object."""
         d["SolarChargingSourceParameters"] = orjson.loads(
-            d.get("SolarChargingSourceParameters", "{}")
+            d.get("SolarChargingSourceParameters") or "{}"
         )
-        d["BopSourceParameters"] = orjson.loads(d.get("BopSourceParameters", "{}"))
+        d["BopSourceParameters"] = orjson.loads(d.get("BopSourceParameters") or "{}")
         return d
 
     @classmethod


### PR DESCRIPTION
# Proposed Changes

The source parameters can be empty strings, as shown in this report/comment:

https://github.com/home-assistant/core/issues/134022#issuecomment-2568788445

```
Error setting up entry Peblar for peblar
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/config_entries.py", line 640, in __async_setup_with_context
    result = await component.async_setup_entry(hass, self)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/components/peblar/__init__.py", line 51, in async_setup_entry
    api = await peblar.rest_api(enable=True, access_mode=AccessMode.READ_WRITE)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/peblar/peblar.py", line 124, in rest_api
    user = await self.user_configuration()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/peblar/peblar.py", line 235, in user_configuration
    return PeblarUserConfiguration.from_json(result)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^
  File "<string>", line 4, in __mashumaro_from_json__
  File "/usr/local/lib/python3.13/site-packages/peblar/models.py", line 414, in __pre_deserialize__
    d["BopSourceParameters"] = orjson.loads(d.get("BopSourceParameters", "{}"))
                               ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
orjson.JSONDecodeError: Input is a zero-length, empty document: line 1 column 1 (char 0)
```

The existing code handled the case of missing source parameters, but not empty ones. This PR corrects that.
