### PR TITLE
Handle Peblar without customization firmware

### DIFF
--- a/src/peblar/models.py
+++ b/src/peblar/models.py
@@ -115,10 +115,12 @@ class PeblarLogin(BaseModel):
 class PeblarVersions(BaseModel):
     """Object holding the version information of the Peblar charger."""
 
-    customization: str = field(metadata=field_options(alias="Customization"))
+    customization: str | None = field(
+        default=None, metadata=field_options(alias="Customization")
+    )
     firmware: str = field(metadata=field_options(alias="Firmware"))
 
-    customization_version: AwesomeVersion
+    customization_version: AwesomeVersion | None = None
     firmware_version: AwesomeVersion
 
     @classmethod
@@ -127,7 +129,8 @@ class PeblarVersions(BaseModel):
         # Strip off everything until the first `-` for the customization
         # for AwesomeVersion to parse it correctly.
         # E.g., `Peblar-1.8`
-        d["customization_version"] = d.get("Customization", "").split("-")[-1]
+        if customization := d.get("Customization"):
+            d["customization_version"] = customization.split("-")[-1]
 
         # Strip off everything after the first + for the firmware
         # for AwesomeVersion to parse it correctly.


### PR DESCRIPTION
# Proposed Changes

There are Peblar white-labeled products around that apparently do not have customizations in their firmware.


As reported here: <https://github.com/home-assistant/core/issues/134022#issuecomment-2568817415>

![image](https://github.com/user-attachments/assets/17232183-eecc-49c8-b265-813834e1e9a9)

```
Unexpected error fetching Peblar Peblar version data
Traceback (most recent call last):
File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 379, in _async_refresh
self.data = await self._async_update_data()
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/usr/src/homeassistant/homeassistant/components/peblar/coordinator.py", line 81, in handler
return await func(self, *args, **kwargs)
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/usr/src/homeassistant/homeassistant/components/peblar/coordinator.py", line 133, in _async_update_data
available=await self.peblar.available_versions(),
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/usr/local/lib/python3.13/site-packages/peblar/peblar.py", line 190, in available_versions
return PeblarVersions.from_json(result)
~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^
File "", line 8, in mashumaro_from_json
mashumaro.exceptions.MissingField: Field "customization" of type str is missing in PeblarVersions instance
```

This PR mitigates that, by marking this field optional. This will need a small adjustment in Home Assistant upstream, to only create the update entities when the customization firmware is present.
