### PR TITLE
Fix ChargeLimiter.LOCAL_SCHEDULED string value

### DIFF
--- a/src/peblar/const.py
+++ b/src/peblar/const.py
@@ -110,7 +110,7 @@ class ChargeLimiter(StrEnum):
     LOCAL_REST_API = "Local REST API"
     """Charging limited by the maximum current by local REST API."""
 
-    LOCAL_SCHEDULED = "Local scheduled"
+    LOCAL_SCHEDULED = "Local scheduled charging"
     """Charging limited by the local schedule."""
 
     OCPP_SMART_CHARGING = "OCPP smart charging"
@@ -152,6 +152,9 @@ class CPState(StrEnum):
 
     INVALID = "Invalid"
     """Invalid CP measured."""
+
+    UNKNOWN = "Unknown"
+    """CP signal cannot be measured."""
 
 
 class PackageType(StrEnum):

--- a/src/peblar/const.py
+++ b/src/peblar/const.py
@@ -110,7 +110,7 @@ class ChargeLimiter(StrEnum):
     LOCAL_REST_API = "Local REST API"
     """Charging limited by the maximum current by local REST API."""
 
-    LOCAL_SCHEDULED = "Local scheduled charging"
+    LOCAL_SCHEDULED_CHARGING = "Local scheduled charging"
     """Charging limited by the local schedule."""
 
     OCPP_SMART_CHARGING = "OCPP smart charging"


### PR DESCRIPTION
# Proposed Changes

* Fix string value of `ChargeLimiter.LOCAL_SCHEDULED` to match the string in the Peblar REST API documentation.
* Add missing `CPState.UNKNOWN` value, according to the Peblar REST API documentation.

## Related Issues

* home-assistant/core#135885
