### PR TITLE
Remove upstream deprecated model properties

### DIFF
--- a/src/peblar/cli/__init__.py
+++ b/src/peblar/cli/__init__.py
@@ -467,14 +467,8 @@ async def system_information(
         "Hardware fixed cable rating",
         f"{info.hardware_fixed_cable_rating}A",
     )
-    table.add_row(
-        "Hardware has 4P relay", convert_to_string(info.hardware_has_4p_relay)
-    )
     table.add_row("Hardware has BOP", convert_to_string(info.hardware_has_bop))
     table.add_row("Hardware has buzzer", convert_to_string(info.hardware_has_buzzer))
-    table.add_row(
-        "Hardware has dual socket", convert_to_string(info.hardware_has_dual_socket)
-    )
     table.add_row(
         "Hardware has Eichrecht laser marking",
         convert_to_string(info.hardware_has_eichrecht_laser_marking),
@@ -491,7 +485,6 @@ async def system_information(
     table.add_row("Hardware has PLC", convert_to_string(info.hardware_has_plc))
     table.add_row("Hardware has RFID", convert_to_string(info.hardware_has_rfid))
     table.add_row("Hardware has RS485", convert_to_string(info.hardware_has_rs485))
-    table.add_row("Hardware has shutter", convert_to_string(info.hardware_has_shutter))
     table.add_row("Hardware has socket", convert_to_string(info.hardware_has_socket))
     table.add_row("Hardware has TPM", convert_to_string(info.hardware_has_tpm))
     table.add_row("Hardware has WLAN", convert_to_string(info.hardware_has_wlan))
@@ -499,9 +492,6 @@ async def system_information(
     table.add_row(
         "Hardware one or three phase",
         convert_to_string(info.hardware_one_or_three_phase),
-    )
-    table.add_row(
-        "Hardware UK compliant", convert_to_string(info.hardware_uk_compliant)
     )
     table.add_row("Hostname", info.hostname)
     table.add_row("Mainboard part number", info.mainboard_part_number)

--- a/src/peblar/models.py
+++ b/src/peblar/models.py
@@ -176,12 +176,8 @@ class PeblarSystemInformation(BaseModel):
     hardware_firmware_compatibility: str = field(
         metadata=field_options(alias="HwFwCompat")
     )
-    hardware_has_4p_relay: bool = field(metadata=field_options(alias="HwHas4pRelay"))
     hardware_has_bop: bool = field(metadata=field_options(alias="HwHasBop"))
     hardware_has_buzzer: bool = field(metadata=field_options(alias="HwHasBuzzer"))
-    hardware_has_dual_socket: bool = field(
-        metadata=field_options(alias="HwHasDualSocket")
-    )
     hardware_has_eichrecht_laser_marking: bool = field(
         metadata=field_options(alias="HwHasEichrechtLaserMarking")
     )
@@ -195,16 +191,12 @@ class PeblarSystemInformation(BaseModel):
     hardware_has_plc: bool = field(metadata=field_options(alias="HwHasPlc"))
     hardware_has_rfid: bool = field(metadata=field_options(alias="HwHasRfid"))
     hardware_has_rs485: bool = field(metadata=field_options(alias="HwHasRs485"))
-    hardware_has_shutter: bool = field(metadata=field_options(alias="HwHasShutter"))
     hardware_has_socket: bool = field(metadata=field_options(alias="HwHasSocket"))
     hardware_has_tpm: bool = field(metadata=field_options(alias="HwHasTpm"))
     hardware_has_wlan: bool = field(metadata=field_options(alias="HwHasWlan"))
     hardware_max_current: int = field(metadata=field_options(alias="HwMaxCurrent"))
     hardware_one_or_three_phase: int = field(
         metadata=field_options(alias="HwOneOrThreePhase")
-    )
-    hardware_uk_compliant: bool | None = field(
-        default=None, metadata=field_options(alias="HwUKCompliant")
     )
     mainboard_part_number: str = field(metadata=field_options(alias="MainboardPn"))
     mainboard_serial_number: str = field(metadata=field_options(alias="MainboardSn"))


### PR DESCRIPTION
# Proposed Changes

Peblar informed me that the `HwHas4pRelay`, `HwHasDualSocket`, `HwUKCompliant`, and `HwHasShutter` system information properties are going away soon (and some models don't even have them).

Since this library is still young and since Home Assistant doesn't use these properties, I've removed them at this point.