### PR TITLE
Use SPDX license identifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "peblar"
 version = "0.0.0"
-license = { text = "MIT License" }
+license = "MIT"
 description = "Asynchronous Python client for Peblar EV chargers."
 authors = [{ name = "Franck Nijhof", email = "opensource@frenck.dev"}]
 maintainers = [{ name = "Franck Nijhof", email = "opensource@frenck.dev"}]
@@ -180,5 +180,5 @@ dev-dependencies = [
 ]
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling>=1.27.0"]
 build-backend = "hatchling.build"


### PR DESCRIPTION
# Proposed Changes

Hatchling `1.27.0` added support for PEP 639 license expressions.
https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files