### PR TITLE
Add INTERNAL_POWER_LIMIT to ChargeLimiter enum

### DIFF
--- a/src/peblar/const.py
+++ b/src/peblar/const.py
@@ -104,6 +104,9 @@ class ChargeLimiter(StrEnum):
     INSTALLATION_LIMIT = "Installation limit"
     """Charging limited by the maximum installation current configured."""
 
+    INTERNAL_POWER_LIMIT = "Internal power limit"
+    """Charging limited by the internal power limit of the charger."""
+
     LOCAL_MODBUS_API = "Local Modbus API"
     """Charging limited by the maximum current by local Modbus API."""
 

--- a/src/peblar/const.py
+++ b/src/peblar/const.py
@@ -105,7 +105,7 @@ class ChargeLimiter(StrEnum):
     """Charging limited by the maximum installation current configured."""
 
     INTERNAL_POWER_LIMIT = "Internal power limit"
-    """Charging limited by the internal power limit of the charger."""
+    """Charging limited by the internal power limit of the vehicle."""
 
     LOCAL_MODBUS_API = "Local Modbus API"
     """Charging limited by the maximum current by local Modbus API."""


### PR DESCRIPTION
# Proposed Changes

The `evinterface` endpoind returned:

```json
{
	"ChargeCurrentLimit" : 32000,
	"ChargeCurrentLimitActual" : 31768,
	"ChargeCurrentLimitSource" : "Internal power limit",
	"CpState" : "State C",
	"Force1Phase" : false
}
```

but the string is missing in  the `ChargeLimiter` enum