### PR TITLE
Add socket unlock action and lock_state to EV interface

### DIFF
--- a/src/peblar/cli/__init__.py
+++ b/src/peblar/cli/__init__.py
@@ -202,6 +202,42 @@ async def identify(
     print_cli_success(quiet=quiet, message="✅[green]Success!")
 
 
+@cli.command("unlock")
+async def unlock(
+    host: Annotated[
+        str,
+        typer.Option(
+            help="Peblar charger IP address or hostname",
+            prompt="Host address",
+            show_default=False,
+            envvar="PEBLAR_HOST",
+        ),
+    ],
+    password: Annotated[
+        str,
+        typer.Option(
+            help="Peblar charger login password",
+            prompt="Password",
+            show_default=False,
+            hide_input=True,
+            envvar="PEBLAR_PASSWORD",
+        ),
+    ],
+    quiet: Annotated[bool, QUIET_OPTION] = False,
+) -> None:
+    """Unlock the socket of the Peblar charger."""
+    status_ctx = (
+        contextlib.nullcontext()
+        if quiet
+        else console.status("[cyan]Unlocking...", spinner="toggle12")
+    )
+    with status_ctx:
+        async with Peblar(host=host) as peblar:
+            await peblar.login(password=password)
+            await peblar.socket_unlock()
+    print_cli_success(quiet=quiet, message="✅[green]Success!")
+
+
 @cli.command("reboot")
 async def reboot(
     host: Annotated[

--- a/src/peblar/models.py
+++ b/src/peblar/models.py
@@ -540,6 +540,9 @@ class PeblarEVInterface(BaseModel):
     )
     cp_state: CPState = field(metadata=field_options(alias="CpState"))
     force_single_phase: bool = field(metadata=field_options(alias="Force1Phase"))
+    lock_state: bool | None = field(
+        default=None, metadata=field_options(alias="LockState")
+    )
 
 
 @dataclass(kw_only=True)
@@ -551,6 +554,9 @@ class PeblarEVInterfaceChange(BaseModel):
     )
     force_single_phase: bool | None = field(
         default=None, metadata=field_options(alias="Force1Phase")
+    )
+    lock_state: bool | None = field(
+        default=None, metadata=field_options(alias="LockState")
     )
 
 

--- a/src/peblar/models.py
+++ b/src/peblar/models.py
@@ -555,9 +555,6 @@ class PeblarEVInterfaceChange(BaseModel):
     force_single_phase: bool | None = field(
         default=None, metadata=field_options(alias="Force1Phase")
     )
-    lock_state: bool | None = field(
-        default=None, metadata=field_options(alias="LockState")
-    )
 
 
 @dataclass(kw_only=True)

--- a/src/peblar/peblar.py
+++ b/src/peblar/peblar.py
@@ -390,16 +390,22 @@ class PeblarApi:
         *,
         charge_current_limit: int | None = None,
         force_single_phase: bool | None = None,
+        lock_state: bool | None = None,
     ) -> PeblarEVInterface:
         """Get information about the EV interface."""
         url = URL("evinterface")
-        if charge_current_limit is not None or force_single_phase is not None:
+        if (
+            charge_current_limit is not None
+            or force_single_phase is not None
+            or lock_state is not None
+        ):
             await self.request(
                 url,
                 method=hdrs.METH_PATCH,
                 data=PeblarEVInterfaceChange(
                     charge_current_limit=charge_current_limit,
                     force_single_phase=force_single_phase,
+                    lock_state=lock_state,
                 ),
             )
 

--- a/src/peblar/peblar.py
+++ b/src/peblar/peblar.py
@@ -257,6 +257,10 @@ class Peblar:
             method=hdrs.METH_DELETE,
         )
 
+    async def socket_unlock(self) -> None:
+        """Unlock the socket of the Peblar charger."""
+        await self.request(URL("system/socket-unlock"), method=hdrs.METH_POST)
+
     async def reboot(self) -> None:
         """Reboot the Peblar charger."""
         await self.request(
@@ -390,22 +394,16 @@ class PeblarApi:
         *,
         charge_current_limit: int | None = None,
         force_single_phase: bool | None = None,
-        lock_state: bool | None = None,
     ) -> PeblarEVInterface:
         """Get information about the EV interface."""
         url = URL("evinterface")
-        if (
-            charge_current_limit is not None
-            or force_single_phase is not None
-            or lock_state is not None
-        ):
+        if charge_current_limit is not None or force_single_phase is not None:
             await self.request(
                 url,
                 method=hdrs.METH_PATCH,
                 data=PeblarEVInterfaceChange(
                     charge_current_limit=charge_current_limit,
                     force_single_phase=force_single_phase,
-                    lock_state=lock_state,
                 ),
             )
 

--- a/tests/cli/__snapshots__/test_cli.ambr
+++ b/tests/cli/__snapshots__/test_cli.ambr
@@ -111,6 +111,11 @@
       'password',
       'quiet',
     ]),
+    'unlock': list([
+      'host',
+      'password',
+      'quiet',
+    ]),
     'update': list([
       'customization',
       'firmware',

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -187,6 +187,13 @@ def test_identify(runner: CliRunner) -> None:
     assert exit_code == 0
 
 
+def test_unlock(runner: CliRunner) -> None:
+    """Unlock command invokes peblar.socket_unlock()."""
+    mock_cls = _mock_peblar(login=None, socket_unlock=None)
+    exit_code, _ = _invoke(runner, ["unlock", *_AUTH], mock_cls)
+    assert exit_code == 0
+
+
 def test_reboot(runner: CliRunner) -> None:
     """Reboot command invokes peblar.reboot()."""
     mock_cls = _mock_peblar(login=None, reboot=None)

--- a/tests/test_peblar.py
+++ b/tests/test_peblar.py
@@ -396,6 +396,25 @@ async def test_api_ev_interface_patch_then_read() -> None:
     assert ev.charge_current_limit == 16000
 
 
+async def test_api_ev_interface_lock_state() -> None:
+    """Test lock_state is parsed from a socket charger response."""
+    body = patched_fixture("ev_interface.json", LockState=True)
+    with aioresponses() as mocked:
+        mocked.get(API_EV_URL, status=200, body=body)
+        async with PeblarApi(host=HOST, token="t") as api:
+            ev = await api.ev_interface()
+    assert ev.lock_state is True
+
+
+async def test_api_ev_interface_lock_state_absent() -> None:
+    """Test lock_state is None on fixed-cable chargers (field absent)."""
+    with aioresponses() as mocked:
+        mocked.get(API_EV_URL, status=200, body=load_fixture("ev_interface.json"))
+        async with PeblarApi(host=HOST, token="t") as api:
+            ev = await api.ev_interface()
+    assert ev.lock_state is None
+
+
 async def test_api_401_authentication_error() -> None:
     """Test PeblarApi 401 is surfaced as PeblarAuthenticationError."""
     with aioresponses() as mocked:

--- a/tests/test_peblar.py
+++ b/tests/test_peblar.py
@@ -76,6 +76,19 @@ async def test_identify() -> None:
             await peblar.identify()
 
 
+async def test_socket_unlock() -> None:
+    """Test socket_unlock posts to the socket-unlock endpoint."""
+    with aioresponses() as mocked:
+        mocked.post(
+            BASE_URL + "system/socket-unlock",
+            status=200,
+            body="",
+            content_type="text/plain",
+        )
+        async with Peblar(host=HOST) as peblar:
+            await peblar.socket_unlock()
+
+
 async def test_request_with_shared_session() -> None:
     """Test a passed-in shared session is reused by the client."""
     with aioresponses() as mocked:


### PR DESCRIPTION
# Proposed Changes

For Peblar chargers with a socket (as opposed to fixed cable), the lock state of the socket is exposed via the EV interface. This PR adds support for reading that state and triggering an immediate unlock.

- Expose `lock_state` (nullable `bool`) on `PeblarEVInterface`, this is `None` on fixed-cable chargers that don't have a lockable socket
- Add `socket_unlock()` to trigger an immediate unlock via `POST /api/v1/system/socket-unlock`

Tested against my Peblar Business (socket).

Note: This was initially part of https://github.com/frenck/python-peblar/pull/382 but I moved it to a separate PR since this particular change does not involve the management API / potential flash wearout issues.