### PR TITLE
Make HwFixedCableRating optional for socket chargers

### DIFF
--- a/src/peblar/cli/__init__.py
+++ b/src/peblar/cli/__init__.py
@@ -702,7 +702,9 @@ async def system_information(
     table.add_row("Firmware version", info.firmware_version)
     table.add_row(
         "Hardware fixed cable rating",
-        f"{info.hardware_fixed_cable_rating}A",
+        f"{info.hardware_fixed_cable_rating}A"
+        if info.hardware_fixed_cable_rating is not None
+        else "N/A (socket charger)",
     )
     table.add_row("Hardware has BOP", convert_to_string(info.hardware_has_bop))
     table.add_row("Hardware has buzzer", convert_to_string(info.hardware_has_buzzer))

--- a/src/peblar/models.py
+++ b/src/peblar/models.py
@@ -209,8 +209,8 @@ class PeblarSystemInformation(BaseModel):
     ethernet_mac_address: str = field(metadata=field_options(alias="EthMacAddr"))
     firmware_version: str = field(metadata=field_options(alias="FwIdent"))
     hostname: str = field(metadata=field_options(alias="Hostname"))
-    hardware_fixed_cable_rating: int = field(
-        metadata=field_options(alias="HwFixedCableRating")
+    hardware_fixed_cable_rating: int | None = field(
+        default=None, metadata=field_options(alias="HwFixedCableRating")
     )
     hardware_firmware_compatibility: str = field(
         metadata=field_options(alias="HwFwCompat")

--- a/tests/test_peblar.py
+++ b/tests/test_peblar.py
@@ -548,6 +548,20 @@ def test_system_information_whitelabel_missing_pubkey() -> None:
     assert info.hostname == "PBLR-0000001"
 
 
+def test_system_information_missing_fixed_cable_rating() -> None:
+    """Test socket chargers that omit HwFixedCableRating.
+
+    Socket-variant Peblar chargers (e.g. Peblar Business) do not include
+    the HwFixedCableRating field starting from firmware 1.8. The model
+    must parse successfully with the field set to None.
+    """
+    body = patched_fixture("system_information.json")
+    data = orjson.loads(body)
+    del data["HwFixedCableRating"]
+    info = PeblarSystemInformation.from_json(orjson.dumps(data))
+    assert info.hardware_fixed_cable_rating is None
+
+
 def test_versions_missing_fields() -> None:
     """Test PeblarVersions handles missing Customization and Firmware."""
     versions = PeblarVersions.from_json("{}")


### PR DESCRIPTION
## Summary

- Make `hardware_fixed_cable_rating` optional (`int | None`, default `None`) on `PeblarSystemInformation`
- Socket-variant chargers (e.g. Peblar Business) do not include `HwFixedCableRating` starting from firmware 1.8
- CLI info command shows "N/A (socket charger)" when the field is absent
- Regression test included

Reported by Peblar ahead of their 1.8 firmware rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)