### PR TITLE
Add automatic API token refresh on 401 for PeblarApi

### DIFF
--- a/src/peblar/peblar.py
+++ b/src/peblar/peblar.py
@@ -77,7 +77,7 @@ class Peblar:
     session: ClientSession | None = None
 
     _close_session: bool = False
-    _password: str | None = None
+    _password: str | None = field(default=None, init=False, repr=False)
 
     def __post_init__(self) -> None:
         """Initialize the Peblar object."""
@@ -134,11 +134,11 @@ class Peblar:
     async def login(self, *, password: str) -> None:
         """Log in to the Peblar charger.
 
-        The password is stored internally so that PeblarApi instances
-        created via rest_api() can transparently re-authenticate when
-        the API token becomes invalid (e.g. after a charger reboot).
+        The password is stored internally (only after a successful login)
+        so that PeblarApi instances created via rest_api() can
+        transparently re-authenticate when the API token becomes invalid
+        (e.g. after a charger reboot).
         """
-        self._password = password
         await self.request(
             URL("auth/login"),
             method=hdrs.METH_POST,
@@ -146,6 +146,7 @@ class Peblar:
                 password=password,
             ),
         )
+        self._password = password
 
     async def rest_api(
         self,
@@ -450,7 +451,7 @@ class PeblarApi:
                     return await self.request(
                         uri, method=method, data=data, _refreshed=True
                     )
-                msg = "Authentication error. Provided password is invalid."
+                msg = "Authentication error. API token is invalid or expired."
                 raise PeblarAuthenticationError(msg) from exception
             msg = "Error occurred while communicating to the Peblar charger API"
             raise PeblarError(msg) from exception

--- a/src/peblar/peblar.py
+++ b/src/peblar/peblar.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import socket
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Self, TypedDict
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Self, TypedDict
 
 import orjson
 from aiohttp import ClientResponseError, CookieJar, hdrs
@@ -50,6 +50,8 @@ from .models import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Coroutine
+
     from peblar.const import AccessMode, PackageType, SmartChargingMode
 
 
@@ -75,6 +77,7 @@ class Peblar:
     session: ClientSession | None = None
 
     _close_session: bool = False
+    _password: str | None = None
 
     def __post_init__(self) -> None:
         """Initialize the Peblar object."""
@@ -129,7 +132,13 @@ class Peblar:
         return await response.text()
 
     async def login(self, *, password: str) -> None:
-        """Log in to the Peblar charger."""
+        """Log in to the Peblar charger.
+
+        The password is stored internally so that PeblarApi instances
+        created via rest_api() can transparently re-authenticate when
+        the API token becomes invalid (e.g. after a charger reboot).
+        """
+        self._password = password
         await self.request(
             URL("auth/login"),
             method=hdrs.METH_POST,
@@ -169,7 +178,11 @@ class Peblar:
             msg = "The local REST API is not enabled for this device."
             raise PeblarError(msg)
 
-        return PeblarApi(host=self.host, token=await self.api_token())
+        return PeblarApi(
+            host=self.host,
+            token=await self.api_token(),
+            token_refresh=self._refresh_api_token,
+        )
 
     async def modbus_api(
         self,
@@ -333,6 +346,19 @@ class Peblar:
             data=user_configuration,
         )
 
+    async def _refresh_api_token(self) -> str:
+        """Re-login and return a fresh API token.
+
+        Called by PeblarApi when it receives a 401, allowing it to
+        transparently recover from token invalidation (e.g. after a
+        charger reboot or firmware update).
+        """
+        if self._password is None:
+            msg = "Cannot refresh API token: no password stored (call login() first)"
+            raise PeblarAuthenticationError(msg)
+        await self.login(password=self._password)
+        return await self.api_token()
+
     async def close(self) -> None:
         """Close open client session."""
         if self.session and self._close_session:
@@ -367,6 +393,9 @@ class PeblarApi:
     token: str
     request_timeout: float = 8
     session: ClientSession | None = None
+    token_refresh: Callable[[], Coroutine[Any, Any, str]] | None = field(
+        default=None, repr=False
+    )
 
     _close_session: bool = False
 
@@ -386,6 +415,7 @@ class PeblarApi:
         *,
         method: str = hdrs.METH_GET,
         data: BaseModel | None = None,
+        _refreshed: bool = False,
     ) -> str:
         """Handle a request to a Peblar charger Local REST API."""
         if self.session is None:
@@ -411,6 +441,15 @@ class PeblarApi:
             raise PeblarConnectionTimeoutError(msg) from exception
         except ClientResponseError as exception:
             if exception.status == 401:
+                # If a token_refresh callback is available and we haven't
+                # already retried, re-login and retry the request once.
+                # This handles token invalidation after charger reboots
+                # or firmware updates.
+                if not _refreshed and self.token_refresh is not None:
+                    self.token = await self.token_refresh()
+                    return await self.request(
+                        uri, method=method, data=data, _refreshed=True
+                    )
                 msg = "Authentication error. Provided password is invalid."
                 raise PeblarAuthenticationError(msg) from exception
             msg = "Error occurred while communicating to the Peblar charger API"

--- a/tests/test_peblar.py
+++ b/tests/test_peblar.py
@@ -472,6 +472,80 @@ async def test_api_401_authentication_error() -> None:
                 await api.health()
 
 
+async def test_api_token_refresh_on_401() -> None:
+    """Test PeblarApi refreshes the token and retries on a 401.
+
+    Simulates a charger reboot that invalidates the API token. The first
+    request returns 401, the token_refresh callback provides a fresh
+    token, and the retried request succeeds.
+    """
+
+    async def fake_refresh() -> str:
+        return "refreshed-token"
+
+    with aioresponses() as mocked:
+        # First call: 401 (stale token)
+        mocked.get(API_HEALTH_URL, status=401, body="", content_type="text/plain")
+        # Second call after refresh: success
+        mocked.get(API_HEALTH_URL, status=200, body=load_fixture("health.json"))
+        async with PeblarApi(
+            host=HOST, token="stale-token", token_refresh=fake_refresh
+        ) as api:
+            health = await api.health()
+    assert health.access_mode == AccessMode.READ_WRITE
+    assert api.token == "refreshed-token"
+
+
+async def test_api_token_refresh_still_fails() -> None:
+    """Test PeblarApi raises after refresh if the retried request also 401s."""
+
+    async def fake_refresh() -> str:
+        return "also-bad-token"
+
+    with aioresponses() as mocked:
+        # First call: 401
+        mocked.get(API_HEALTH_URL, status=401, body="", content_type="text/plain")
+        # Retry after refresh: still 401
+        mocked.get(API_HEALTH_URL, status=401, body="", content_type="text/plain")
+        async with PeblarApi(
+            host=HOST, token="stale", token_refresh=fake_refresh
+        ) as api:
+            with pytest.raises(PeblarAuthenticationError):
+                await api.health()
+
+
+async def test_api_401_without_refresh_callback() -> None:
+    """Test PeblarApi 401 raises immediately when no token_refresh is set."""
+    with aioresponses() as mocked:
+        mocked.get(API_HEALTH_URL, status=401, body="", content_type="text/plain")
+        async with PeblarApi(host=HOST, token="t") as api:
+            with pytest.raises(PeblarAuthenticationError):
+                await api.health()
+
+
+async def test_peblar_login_stores_password_for_refresh() -> None:
+    """Test that login() stores the password so rest_api() can refresh tokens."""
+    with aioresponses() as mocked:
+        mocked.post(LOGIN_URL, status=200, body="", content_type="text/plain")
+        mocked.get(
+            USER_CONFIG_URL, status=200, body=load_fixture("user_configuration.json")
+        )
+        mocked.get(API_TOKEN_URL, status=200, body=load_fixture("api_token.json"))
+        async with Peblar(host=HOST) as peblar:
+            await peblar.login(password="test-pass")
+            api = await peblar.rest_api()
+            await api.close()
+    assert api.token_refresh is not None
+
+
+async def test_peblar_refresh_without_login_raises() -> None:
+    """Test _refresh_api_token raises when login() was never called."""
+    peblar = Peblar(host=HOST)
+    with pytest.raises(PeblarAuthenticationError, match="no password stored"):
+        await peblar._refresh_api_token()
+    await peblar.close()
+
+
 async def test_api_timeout() -> None:
     """Test PeblarApi request timeout is surfaced as PeblarConnectionTimeoutError."""
     with aioresponses() as mocked:

--- a/tests/test_peblar.py
+++ b/tests/test_peblar.py
@@ -542,7 +542,7 @@ async def test_peblar_refresh_without_login_raises() -> None:
     """Test _refresh_api_token raises when login() was never called."""
     peblar = Peblar(host=HOST)
     with pytest.raises(PeblarAuthenticationError, match="no password stored"):
-        await peblar._refresh_api_token()
+        await peblar._refresh_api_token()  # pylint: disable=protected-access
     await peblar.close()
 
 


### PR DESCRIPTION
# Proposed Changes

- When `PeblarApi` receives a 401 (e.g. after a charger reboot or firmware update that invalidates the API token), it now automatically re-logins via the parent `Peblar` instance, fetches a fresh token, and retries the request once
- If the retry also fails with 401, `PeblarAuthenticationError` is raised as before
- `PeblarApi` instances created directly (without going through `Peblar.rest_api()`) behave exactly as before: 401 raises immediately

## How it works

- `Peblar.login()` now stores the password internally
- `Peblar.rest_api()` passes a `token_refresh` callback to `PeblarApi` that re-logins and returns a fresh API token
- `PeblarApi.request()` catches 401, calls the callback if available, updates its token, and retries once (a `_refreshed` flag prevents infinite loops)

## Why

The Peblar charger's API token can become invalid after a reboot or firmware update. The Home Assistant integration currently surfaces this as a user-facing reauthentication prompt every few days (home-assistant/core#138535). With this change, the library handles recovery transparently and consumers no longer need to implement their own re-login logic.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
