### PR TITLE
Add household power limit setting

### DIFF
--- a/src/peblar/cli/__init__.py
+++ b/src/peblar/cli/__init__.py
@@ -298,6 +298,104 @@ async def unlock_cmd(
     print_cli_success(quiet=quiet, message="✅[green]Success!")
 
 
+@cli.command("household-limit")
+async def household_limit_cmd(
+    host: Annotated[
+        str,
+        typer.Option(
+            help="Peblar charger IP address or hostname",
+            prompt="Host address",
+            show_default=False,
+            envvar="PEBLAR_HOST",
+        ),
+    ],
+    password: Annotated[
+        str,
+        typer.Option(
+            help="Peblar charger login password",
+            prompt="Password",
+            show_default=False,
+            hide_input=True,
+            envvar="PEBLAR_PASSWORD",
+        ),
+    ],
+    limit: Annotated[
+        int | None,
+        typer.Option(
+            help="Household power limit in watts",
+            show_default=False,
+        ),
+    ] = None,
+    enable: Annotated[
+        bool,
+        typer.Option(
+            help="Enable the household power limit",
+        ),
+    ] = False,
+    disable: Annotated[
+        bool,
+        typer.Option(
+            help="Disable the household power limit",
+        ),
+    ] = False,
+    quiet: Annotated[bool, QUIET_OPTION] = False,
+) -> None:
+    """Show or change the household power limit.
+
+    Without flags, shows the current setting. Pass --limit to set the
+    power limit (in watts), --enable / --disable to toggle it.
+    """
+    if enable and disable:
+        msg = "--enable cannot be used with --disable."
+        raise typer.BadParameter(msg)
+
+    has_change = limit is not None or enable or disable
+    if has_change:
+        status_ctx = (
+            contextlib.nullcontext()
+            if quiet
+            else console.status("[cyan]Adjusting...", spinner="toggle12")
+        )
+        with status_ctx:
+            async with Peblar(host=host) as peblar:
+                await peblar.login(password=password)
+                await peblar.update_user_configuration(
+                    PeblarSetUserConfiguration(
+                        user_defined_household_power_limit=limit,
+                        user_defined_household_power_limit_enabled=enable or None
+                        if not disable
+                        else False,
+                    ),
+                )
+        print_cli_success(quiet=quiet, message="✅[green]Success!")
+        return
+
+    async with Peblar(host=host) as peblar:
+        await peblar.login(password=password)
+        config = await peblar.user_configuration()
+
+    table = Table(title="Peblar household power limit")
+    table.add_column("Property", style="cyan bold")
+    table.add_column("Value", style="bold")
+
+    table.add_row(
+        "Allowed",
+        convert_to_string(config.user_defined_household_power_limit_allowed),
+    )
+    table.add_row(
+        "Enabled",
+        convert_to_string(config.user_defined_household_power_limit_enabled),
+    )
+    table.add_row(
+        "Power limit",
+        f"{round(config.user_defined_household_power_limit / 1000, 1)} kW"
+        f" ({config.user_defined_household_power_limit} W)",
+    )
+    table.add_row("Source", config.user_defined_household_power_limit_source)
+
+    console.print(table)
+
+
 @cli.command("buzzer")
 async def buzzer(
     host: Annotated[

--- a/src/peblar/cli/__init__.py
+++ b/src/peblar/cli/__init__.py
@@ -299,6 +299,7 @@ async def unlock_cmd(
 
 
 @cli.command("household-limit")
+# pylint: disable=too-many-arguments,too-many-positional-arguments
 async def household_limit_cmd(
     host: Annotated[
         str,

--- a/src/peblar/cli/__init__.py
+++ b/src/peblar/cli/__init__.py
@@ -357,15 +357,19 @@ async def household_limit_cmd(
             if quiet
             else console.status("[cyan]Adjusting...", spinner="toggle12")
         )
+        enabled: bool | None = None
+        if enable:
+            enabled = True
+        elif disable:
+            enabled = False
+
         with status_ctx:
             async with Peblar(host=host) as peblar:
                 await peblar.login(password=password)
                 await peblar.update_user_configuration(
                     PeblarSetUserConfiguration(
                         user_defined_household_power_limit=limit,
-                        user_defined_household_power_limit_enabled=enable or None
-                        if not disable
-                        else False,
+                        user_defined_household_power_limit_enabled=enabled,
                     ),
                 )
         print_cli_success(quiet=quiet, message="✅[green]Success!")
@@ -389,7 +393,7 @@ async def household_limit_cmd(
     )
     table.add_row(
         "Power limit",
-        f"{round(config.user_defined_household_power_limit / 1000, 1)} kW"
+        f"{round(config.user_defined_household_power_limit / 1000, 3)} kW"
         f" ({config.user_defined_household_power_limit} W)",
     )
     table.add_row("Source", config.user_defined_household_power_limit_source)

--- a/src/peblar/models.py
+++ b/src/peblar/models.py
@@ -484,6 +484,14 @@ class PeblarSetUserConfiguration(BaseModel):
     user_defined_charge_limit_current: int | None = field(
         default=None, metadata=field_options(alias="UserDefinedChargeLimitCurrent")
     )
+    user_defined_household_power_limit: int | None = field(
+        default=None,
+        metadata=field_options(alias="UserDefinedHouseholdPowerLimit"),
+    )
+    user_defined_household_power_limit_enabled: bool | None = field(
+        default=None,
+        metadata=field_options(alias="UserDefinedHouseholdPowerLimitEnable"),
+    )
 
 
 @dataclass(kw_only=True)

--- a/tests/cli/__snapshots__/test_cli.ambr
+++ b/tests/cli/__snapshots__/test_cli.ambr
@@ -65,6 +65,14 @@
       'password',
       'quiet',
     ]),
+    'household-limit': list([
+      'disable',
+      'enable',
+      'host',
+      'limit',
+      'password',
+      'quiet',
+    ]),
     'identify': list([
       'host',
       'password',
@@ -225,6 +233,20 @@
   │ API Access mode │ ReadWrite │
   │ API version     │ 1.0       │
   └─────────────────┴───────────┘
+  
+  '''
+# ---
+# name: test_household_limit_show
+  '''
+     Peblar household power limit    
+  ┏━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━┓
+  ┃ Property    ┃ Value             ┃
+  ┡━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━┩
+  │ Allowed     │ ✅                │
+  │ Enabled     │ ❌                │
+  │ Power limit │ 17.5 kW (17500 W) │
+  │ Source      │ notselected       │
+  └─────────────┴───────────────────┘
   
   '''
 # ---

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -180,6 +180,43 @@ def test_config_charge_limit_too_low(runner: CliRunner) -> None:
     assert exit_code != 0
 
 
+def test_household_limit_set(runner: CliRunner) -> None:
+    """Household-limit command with --limit PATCHes the charger."""
+    mock_cls = _mock_peblar(login=None, update_user_configuration=None)
+    exit_code, output = _invoke(
+        runner,
+        ["household-limit", *_AUTH, "--limit", "7500", "--enable"],
+        mock_cls,
+    )
+    assert exit_code == 0
+    assert "Success!" in output
+
+
+def test_household_limit_show(
+    runner: CliRunner,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Household-limit command without flags shows the current setting."""
+    config = PeblarUserConfiguration.from_json(
+        load_fixture("user_configuration.json"),
+    )
+    mock_cls = _mock_peblar(login=None, user_configuration=config)
+    exit_code, output = _invoke(runner, ["household-limit", *_AUTH], mock_cls)
+    assert exit_code == 0
+    assert output == snapshot
+
+
+def test_household_limit_enable_disable_conflict(runner: CliRunner) -> None:
+    """Household-limit command rejects --enable and --disable together."""
+    mock_cls = _mock_peblar(login=None)
+    exit_code, _ = _invoke(
+        runner,
+        ["household-limit", *_AUTH, "--enable", "--disable"],
+        mock_cls,
+    )
+    assert exit_code != 0
+
+
 def test_identify(runner: CliRunner) -> None:
     """Identify command invokes peblar.identify()."""
     mock_cls = _mock_peblar(login=None, identify=None)

--- a/tests/test_peblar.py
+++ b/tests/test_peblar.py
@@ -207,6 +207,19 @@ async def test_smart_charging_default() -> None:
             await peblar.smart_charging(SmartChargingMode.DEFAULT)
 
 
+async def test_update_user_configuration_household_limit() -> None:
+    """Test setting the household power limit via update_user_configuration."""
+    with aioresponses() as mocked:
+        mocked.patch(USER_CONFIG_URL, status=200, body="", content_type="text/plain")
+        async with Peblar(host=HOST) as peblar:
+            await peblar.update_user_configuration(
+                PeblarSetUserConfiguration(
+                    user_defined_household_power_limit=7500,
+                    user_defined_household_power_limit_enabled=True,
+                ),
+            )
+
+
 async def test_socket_lock() -> None:
     """Test socket_lock PATCHes the user config endpoint."""
     with aioresponses() as mocked:


### PR DESCRIPTION
## Summary

- Add `user_defined_household_power_limit` (int, watts) and `user_defined_household_power_limit_enabled` (bool) to `PeblarSetUserConfiguration`
- New CLI command: `peblar household-limit` that shows or changes the household power limit
  - Without flags: shows current setting (allowed, enabled, limit, source)
  - `--limit 7500`: set the power limit in watts
  - `--enable` / `--disable`: toggle the limit on or off
- Tested against a real charger (confirmed the PATCH /config/user endpoint accepts these fields)

Addresses home-assistant/community feature request [#1006](https://github.com/orgs/home-assistant/discussions/1006).

🤖 Generated with [Claude Code](https://claude.com/claude-code)