### PR TITLE
Loosen tenacity dependency to >=8.0.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2867,4 +2867,4 @@ cli = ["rich", "typer", "zeroconf"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11"
-content-hash = "cd958241896bae2e1df079b889fe054d047f018d7cacfcb910a84216361e34f2"
+content-hash = "812173b23315718025e2a44399bff888a99f236b33ab2141c9d9ef303fa7891b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
   'aiohttp (>=3.0.0)',
   'awesomeversion (>=22.8.0)',
   'mashumaro (>=3.10)',
-  'tenacity (>=9.0.0)',
+  'tenacity (>=8.0.0)',
   'orjson (>=3.9.8)',
   'yarl (>=1.6.0)',
 ]


### PR DESCRIPTION
## Summary

Loosen tenacity from >=9.0.0 to >=8.0.0. The APIs we use have been stable since 8.x and the stricter floor caused dependency conflicts in Home Assistant with packages that cap tenacity at <9.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)