### PR TITLE
Fix setup on single phase chargers

### DIFF
--- a/src/peblar/cli/__init__.py
+++ b/src/peblar/cli/__init__.py
@@ -82,7 +82,12 @@ def format_watts(watts: int | None) -> str:
 
 
 def format_volts(volts: int | None) -> str:
-    """Format a voltage reading, or mark it as unmeasurable."""
+    """Format a voltage reading, or mark it as not reported.
+
+    The charger leaves a voltage out both for a phase it does not have
+    and for one it cannot currently measure, so this stays vaguer than
+    the current and power equivalents.
+    """
     if volts is None:
         return "N/A"
     return f"{volts}V"

--- a/src/peblar/cli/__init__.py
+++ b/src/peblar/cli/__init__.py
@@ -67,6 +67,27 @@ def print_cli_success(*, quiet: bool, message: str) -> None:
     console.print(message)
 
 
+def format_amps(milliamps: int | None) -> str:
+    """Format a milliampere reading, or mark the phase as absent."""
+    if milliamps is None:
+        return "N/A (single phase charger)"
+    return f"{round(milliamps / 1000, 3)}A"
+
+
+def format_watts(watts: int | None) -> str:
+    """Format a wattage reading, or mark the phase as absent."""
+    if watts is None:
+        return "N/A (single phase charger)"
+    return f"{watts}W"
+
+
+def format_volts(volts: int | None) -> str:
+    """Format a voltage reading, or mark it as unmeasurable."""
+    if volts is None:
+        return "N/A"
+    return f"{volts}V"
+
+
 def convert_to_string(value: object) -> str:
     """Convert a value to a string."""
     if isinstance(value, bool):
@@ -1857,30 +1878,21 @@ async def meter(
 
     table.add_row("Total power", f"{meter_data.power_total}W")
     table.add_row("Power phase 1", f"{meter_data.power_phase_1}W")
-    table.add_row("Power phase 2", f"{meter_data.power_phase_2}W")
-    table.add_row("Power phase 3", f"{meter_data.power_phase_3}W")
+    table.add_row("Power phase 2", format_watts(meter_data.power_phase_2))
+    table.add_row("Power phase 3", format_watts(meter_data.power_phase_3))
 
     table.add_section()
 
-    total_current = round(
-        (
-            meter_data.current_phase_1
-            + meter_data.current_phase_2
-            + meter_data.current_phase_3
-        )
-        / 1000,
-        3,
-    )
-    table.add_row("Total current", f"{total_current}A")
+    table.add_row("Total current", f"{round(meter_data.current_total / 1000, 3)}A")
     table.add_row("Current Phase 1", f"{round(meter_data.current_phase_1 / 1000, 3)}A")
-    table.add_row("Current Phase 2", f"{round(meter_data.current_phase_2 / 1000, 3)}A")
-    table.add_row("Current Phase 3", f"{round(meter_data.current_phase_3 / 1000, 3)}A")
+    table.add_row("Current Phase 2", format_amps(meter_data.current_phase_2))
+    table.add_row("Current Phase 3", format_amps(meter_data.current_phase_3))
 
     table.add_section()
 
-    table.add_row("Voltage Phase 1", f"{meter_data.voltage_phase_1 or 0}V")
-    table.add_row("Voltage Phase 2", f"{meter_data.voltage_phase_2 or 0}V")
-    table.add_row("Voltage Phase 3", f"{meter_data.voltage_phase_3 or 0}V")
+    table.add_row("Voltage Phase 1", format_volts(meter_data.voltage_phase_1))
+    table.add_row("Voltage Phase 2", format_volts(meter_data.voltage_phase_2))
+    table.add_row("Voltage Phase 3", format_volts(meter_data.voltage_phase_3))
 
     console.print(table)
 

--- a/src/peblar/models.py
+++ b/src/peblar/models.py
@@ -556,7 +556,7 @@ class PeblarSystem(BaseModel):
         metadata=field_options(alias="ActiveWarningCodes")
     )
     cellular_signal_strength: int | None = field(
-        metadata=field_options(alias="CellularSignalStrength")
+        default=None, metadata=field_options(alias="CellularSignalStrength")
     )
     firmware_version: str = field(metadata=field_options(alias="FirmwareVersion"))
     force_single_phase_allowed: bool = field(
@@ -567,7 +567,7 @@ class PeblarSystem(BaseModel):
     product_serial_number: str = field(metadata=field_options(alias="ProductSn"))
     uptime: int = field(metadata=field_options(alias="Uptime"))
     wlan_signal_strength: int | None = field(
-        metadata=field_options(alias="WlanSignalStrength")
+        default=None, metadata=field_options(alias="WlanSignalStrength")
     )
 
 
@@ -658,22 +658,54 @@ class PeblarEVInterfaceChange(BaseModel):
 @dataclass(kw_only=True)
 # pylint: disable-next=too-many-instance-attributes
 class PeblarMeter(BaseModel):
-    """Object holding the meter information of the Peblar charger."""
+    """Object holding the meter information of the Peblar charger.
+
+    Single phase chargers leave the phase 2 and 3 fields out of the
+    response entirely rather than reporting zeros, so everything beyond
+    phase 1 is optional. A phase the charger does not have reads as None,
+    which is not the same as a phase sitting at 0A.
+    """
 
     current_phase_1: int = field(metadata=field_options(alias="CurrentPhase1"))
-    current_phase_2: int = field(metadata=field_options(alias="CurrentPhase2"))
-    current_phase_3: int = field(metadata=field_options(alias="CurrentPhase3"))
+    current_phase_2: int | None = field(
+        default=None, metadata=field_options(alias="CurrentPhase2")
+    )
+    current_phase_3: int | None = field(
+        default=None, metadata=field_options(alias="CurrentPhase3")
+    )
     energy_session: int = field(metadata=field_options(alias="EnergySession"))
     energy_total: int = field(metadata=field_options(alias="EnergyTotal"))
     power_phase_1: int = field(metadata=field_options(alias="PowerPhase1"))
-    power_phase_2: int = field(metadata=field_options(alias="PowerPhase2"))
-    power_phase_3: int = field(metadata=field_options(alias="PowerPhase3"))
+    power_phase_2: int | None = field(
+        default=None, metadata=field_options(alias="PowerPhase2")
+    )
+    power_phase_3: int | None = field(
+        default=None, metadata=field_options(alias="PowerPhase3")
+    )
     power_total: int = field(metadata=field_options(alias="PowerTotal"))
-    voltage_phase_1: int | None = field(metadata=field_options(alias="VoltagePhase1"))
-    voltage_phase_2: int | None = field(metadata=field_options(alias="VoltagePhase2"))
-    voltage_phase_3: int | None = field(metadata=field_options(alias="VoltagePhase3"))
+    voltage_phase_1: int | None = field(
+        default=None, metadata=field_options(alias="VoltagePhase1")
+    )
+    voltage_phase_2: int | None = field(
+        default=None, metadata=field_options(alias="VoltagePhase2")
+    )
+    voltage_phase_3: int | None = field(
+        default=None, metadata=field_options(alias="VoltagePhase3")
+    )
 
     @property
     def current_total(self) -> int:
-        """Return the total current of the Peblar charger."""
-        return self.current_phase_1 + self.current_phase_2 + self.current_phase_3
+        """Return the total current of the Peblar charger.
+
+        Phases the charger does not have are left out rather than counted
+        as zero, so a single phase charger totals just its one phase.
+        """
+        return sum(
+            current
+            for current in (
+                self.current_phase_1,
+                self.current_phase_2,
+                self.current_phase_3,
+            )
+            if current is not None
+        )

--- a/src/peblar/models.py
+++ b/src/peblar/models.py
@@ -661,9 +661,12 @@ class PeblarMeter(BaseModel):
     """Object holding the meter information of the Peblar charger.
 
     Single phase chargers leave the phase 2 and 3 fields out of the
-    response entirely rather than reporting zeros, so everything beyond
-    phase 1 is optional. A phase the charger does not have reads as None,
-    which is not the same as a phase sitting at 0A.
+    response entirely rather than reporting zeros, so those are optional.
+    The voltages are optional on top of that, phase 1 included, since the
+    charger reports nothing for a phase it cannot currently measure.
+
+    A field reading None means the charger did not report it, which is
+    not the same as it reporting 0.
     """
 
     current_phase_1: int = field(metadata=field_options(alias="CurrentPhase1"))

--- a/tests/fixtures/meter_single_phase.json
+++ b/tests/fixtures/meter_single_phase.json
@@ -1,0 +1,8 @@
+{
+  "CurrentPhase1": 0,
+  "EnergySession": 39479,
+  "EnergyTotal": 39479,
+  "PowerPhase1": 0,
+  "PowerTotal": 0,
+  "VoltagePhase1": 219
+}

--- a/tests/fixtures/system_single_phase.json
+++ b/tests/fixtures/system_single_phase.json
@@ -1,0 +1,10 @@
+{
+  "ActiveErrorCodes": [],
+  "ActiveWarningCodes": [],
+  "FirmwareVersion": "1.9.2+1+WL-1",
+  "Force1PhaseAllowed": false,
+  "PhaseCount": 1,
+  "ProductPn": "0000-0000-0000",
+  "ProductSn": "00-00-AAA-000",
+  "Uptime": 39479
+}

--- a/tests/test_peblar.py
+++ b/tests/test_peblar.py
@@ -24,6 +24,7 @@ from peblar.exceptions import (
     PeblarError,
 )
 from peblar.models import (
+    PeblarMeter,
     PeblarSetUserConfiguration,
     PeblarSmartCharging,
     PeblarSystemInformation,
@@ -798,3 +799,56 @@ async def test_delete_rfid_token() -> None:
         )
         async with Peblar(host=HOST) as peblar:
             await peblar.delete_rfid_token(uid="0123456789ABCD")
+
+
+# ---------------------------------------------------------------------------
+# Single phase chargers (home-assistant/core#179900)
+# ---------------------------------------------------------------------------
+async def test_api_meter_single_phase() -> None:
+    """Test a single phase charger that omits the phase 2 and 3 fields."""
+    with aioresponses() as mocked:
+        mocked.get(
+            API_METER_URL, status=200, body=load_fixture("meter_single_phase.json")
+        )
+        async with PeblarApi(host=HOST, token="t") as api:
+            meter = await api.meter()
+
+    assert meter.current_phase_1 == 0
+    assert meter.current_phase_2 is None
+    assert meter.current_phase_3 is None
+    assert meter.power_phase_2 is None
+    assert meter.power_phase_3 is None
+    assert meter.voltage_phase_1 == 219
+    assert meter.voltage_phase_2 is None
+    assert meter.energy_total == 39479
+
+
+def test_meter_current_total_skips_absent_phases() -> None:
+    """Test the total current ignores phases the charger does not have."""
+    single = PeblarMeter.from_json(load_fixture("meter_single_phase.json"))
+    assert single.current_total == 0
+
+    single.current_phase_1 = 10212
+    assert single.current_total == 10212
+
+    three = PeblarMeter.from_json(load_fixture("meter.json"))
+    assert three.current_total == 0
+    three.current_phase_1 = 100
+    three.current_phase_2 = 200
+    three.current_phase_3 = 300
+    assert three.current_total == 600
+
+
+async def test_api_system_single_phase() -> None:
+    """Test a charger that omits the signal strength fields entirely."""
+    with aioresponses() as mocked:
+        mocked.get(
+            API_SYSTEM_URL, status=200, body=load_fixture("system_single_phase.json")
+        )
+        async with PeblarApi(host=HOST, token="t") as api:
+            system = await api.system()
+
+    assert system.phase_count == 1
+    assert system.force_single_phase_allowed is False
+    assert system.wlan_signal_strength is None
+    assert system.cellular_signal_strength is None


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Single phase chargers omit the phase 2 and 3 fields from `/meter` entirely rather than reporting them as zero, so `PeblarMeter` refused to deserialize and the Home Assistant integration could never finish setting up:

```
MissingField: Field "current_phase_2" of type int is missing in PeblarMeter
```

The phase 2 and 3 current and power fields are now optional. The voltage fields were already typed `int | None` but had no default, so mashumaro still required them and they would have failed next; they now default to `None` too. `PeblarSystem` had the same problem with its two signal strength fields.

A phase the charger does not have reads as `None` rather than `0`, because those are different claims. `current_total` therefore sums only the phases that are present, and the CLI meter table renders absent phases instead of doing arithmetic on `None`.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

home-assistant/core#179900

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
