### PR TITLE
Re-login automatically when the charger forgets the session

### DIFF
--- a/src/peblar/peblar.py
+++ b/src/peblar/peblar.py
@@ -57,6 +57,9 @@ if TYPE_CHECKING:
     from peblar.const import AccessMode, PackageType, SmartChargingMode
 
 
+LOGIN_URI = URL("auth/login")
+
+
 class _RfidTokenPayload(TypedDict):
     """Single RFID token payload returned by the standalone list endpoint."""
 
@@ -97,6 +100,7 @@ class Peblar:
         *,
         method: str = hdrs.METH_GET,
         data: BaseModel | None = None,
+        _relogged_in: bool = False,
     ) -> str:
         """Handle a request to a Peblar charger."""
         if self.session is None:
@@ -127,6 +131,17 @@ class Peblar:
             raise PeblarConnectionTimeoutError(msg) from exception
         except ClientResponseError as exception:
             if exception.status == 401:
+                # A session the charger forgot looks exactly like a wrong
+                # password. If we know the password, and this is not the
+                # login call itself, log back in and try once more. The
+                # charger drops sessions on reboot and after a network
+                # blip, which would otherwise force the user to
+                # re-authenticate by hand.
+                if not _relogged_in and self._password is not None and uri != LOGIN_URI:
+                    await self.login(password=self._password)
+                    return await self.request(
+                        uri, method=method, data=data, _relogged_in=True
+                    )
                 msg = "Authentication error. Provided password is invalid."
                 raise PeblarAuthenticationError(msg) from exception
             msg = "Error occurred while communicating to the Peblar charger"
@@ -149,7 +164,7 @@ class Peblar:
         (e.g. after a charger reboot).
         """
         await self.request(
-            URL("auth/login"),
+            LOGIN_URI,
             method=hdrs.METH_POST,
             data=PeblarLogin(
                 password=password,

--- a/tests/test_peblar.py
+++ b/tests/test_peblar.py
@@ -876,12 +876,31 @@ async def test_relogin_on_401_after_session_expiry() -> None:
 
 
 async def test_relogin_only_retries_once() -> None:
-    """Test a password that is genuinely wrong still surfaces."""
+    """Test a charger that keeps rejecting the session gives up after one retry."""
     with aioresponses() as mocked:
         mocked.post(LOGIN_URL, status=204, body="", content_type="text/plain")
         mocked.get(USER_CONFIG_URL, status=401, body="", content_type="text/plain")
         mocked.post(LOGIN_URL, status=204, body="", content_type="text/plain")
         mocked.get(USER_CONFIG_URL, status=401, body="", content_type="text/plain")
+
+        async with Peblar(host=HOST) as peblar:
+            await peblar.login(password="test-pass")
+            with pytest.raises(PeblarAuthenticationError):
+                await peblar.user_configuration()
+
+
+async def test_relogin_surfaces_a_changed_password() -> None:
+    """Test a password changed on the charger still reaches the caller.
+
+    The stored password no longer works, so the automatic re-login is
+    itself rejected. That has to surface, otherwise Home Assistant never
+    asks the user for the new one.
+    """
+    with aioresponses() as mocked:
+        mocked.post(LOGIN_URL, status=204, body="", content_type="text/plain")
+        mocked.get(USER_CONFIG_URL, status=401, body="", content_type="text/plain")
+        # The charger no longer accepts the password we have stored.
+        mocked.post(LOGIN_URL, status=401, body="", content_type="text/plain")
 
         async with Peblar(host=HOST) as peblar:
             await peblar.login(password="test-pass")

--- a/tests/test_peblar.py
+++ b/tests/test_peblar.py
@@ -852,3 +852,59 @@ async def test_api_system_single_phase() -> None:
     assert system.force_single_phase_allowed is False
     assert system.wlan_signal_strength is None
     assert system.cellular_signal_strength is None
+
+
+# Transparent re-login (home-assistant/core#172604, #173297)
+# ---------------------------------------------------------------------------
+async def test_relogin_on_401_after_session_expiry() -> None:
+    """Test a forgotten session is recovered without bothering the user."""
+    with aioresponses() as mocked:
+        mocked.post(LOGIN_URL, status=204, body="", content_type="text/plain")
+        # The charger forgot the session, for example after a reboot.
+        mocked.get(USER_CONFIG_URL, status=401, body="", content_type="text/plain")
+        # Logging back in, then the retried request.
+        mocked.post(LOGIN_URL, status=204, body="", content_type="text/plain")
+        mocked.get(
+            USER_CONFIG_URL, status=200, body=load_fixture("user_configuration.json")
+        )
+
+        async with Peblar(host=HOST) as peblar:
+            await peblar.login(password="test-pass")
+            config = await peblar.user_configuration()
+
+    assert config.local_rest_api_allowed is True
+
+
+async def test_relogin_only_retries_once() -> None:
+    """Test a password that is genuinely wrong still surfaces."""
+    with aioresponses() as mocked:
+        mocked.post(LOGIN_URL, status=204, body="", content_type="text/plain")
+        mocked.get(USER_CONFIG_URL, status=401, body="", content_type="text/plain")
+        mocked.post(LOGIN_URL, status=204, body="", content_type="text/plain")
+        mocked.get(USER_CONFIG_URL, status=401, body="", content_type="text/plain")
+
+        async with Peblar(host=HOST) as peblar:
+            await peblar.login(password="test-pass")
+            with pytest.raises(PeblarAuthenticationError):
+                await peblar.user_configuration()
+
+
+async def test_login_401_does_not_loop() -> None:
+    """Test a rejected login does not try to log in again to fix itself."""
+    with aioresponses() as mocked:
+        mocked.post(LOGIN_URL, status=204, body="", content_type="text/plain")
+        mocked.post(LOGIN_URL, status=401, body="", content_type="text/plain")
+
+        async with Peblar(host=HOST) as peblar:
+            await peblar.login(password="test-pass")
+            with pytest.raises(PeblarAuthenticationError):
+                await peblar.login(password="wrong-pass")
+
+
+async def test_no_relogin_without_a_stored_password() -> None:
+    """Test a client that never logged in has nothing to retry with."""
+    with aioresponses() as mocked:
+        mocked.get(USER_CONFIG_URL, status=401, body="", content_type="text/plain")
+        async with Peblar(host=HOST) as peblar:
+            with pytest.raises(PeblarAuthenticationError):
+                await peblar.user_configuration()


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

v0.5.0 added automatic token refresh on a 401, but only to `PeblarApi`. The `Peblar` class raises `PeblarAuthenticationError` straight away instead.

Home Assistant runs three coordinators: meter data through `PeblarApi`, and both user configuration and version through `Peblar`. So whenever the charger forgets its session, after a reboot or a network blip, the two `Peblar` coordinators turn that 401 into `ConfigEntryAuthFailed` and the user gets a "Reauthenticate with your Peblar EV charger" prompt even though the password never changed.

`Peblar.request` now does what `PeblarApi.request` already did: on a 401, log back in once with the stored password and retry. A genuinely wrong password still surfaces, since the retry happens at most once, never for the login call itself, and never without a password to retry with.

Credit to @cafferata for the root cause analysis in home-assistant/core#172604.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

home-assistant/core#172604
home-assistant/core#173297

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
