### PR TITLE
Fix BOP source parameters being returned as a string

### DIFF
--- a/src/peblar/models.py
+++ b/src/peblar/models.py
@@ -296,7 +296,7 @@ class PeblarUserConfiguration(BaseModel):
         metadata=field_options(alias="BopHomeWizardAddress")
     )
     bop_source: str = field(metadata=field_options(alias="BopSource"))
-    bop_source_parameters: str = field(
+    bop_source_parameters: dict[str, Any] = field(
         metadata=field_options(alias="BopSourceParameters")
     )
     connected_phases: int = field(metadata=field_options(alias="ConnectedPhases"))

--- a/tests/cli/__snapshots__/test_cli.ambr
+++ b/tests/cli/__snapshots__/test_cli.ambr
@@ -167,69 +167,69 @@
 # ---
 # name: test_config
   '''
-                             Peblar user configuration                            
-  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
-  ┃ Property                                      ┃ Value                        ┃
-  ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
-  │ BOP fallback current                          │ 6000                         │
-  │ BOP HomeWizard address                        │                              │
-  │ BOP source parameters                         │ {'address': 'redacted-host'} │
-  │ BOP source                                    │ homewizard                   │
-  │ Buzzer volume                                 │ 4                            │
-  │ Connected phases                              │ 3                            │
-  │ Current control BOP CT type                   │ CTK05-14                     │
-  │ Current control BOP enabled                   │ ✅                           │
-  │ Current control BOP fuse rating               │ 25A                          │
-  │ Current control fixed charge current limit    │ 16                           │
-  │ Ground monitoring                             │ ✅                           │
-  │ Group load balancing enabled                  │ ❌                           │
-  │ Group load balancing fallback current         │ 6A                           │
-  │ Group load balancing group ID                 │ 1                            │
-  │ Group load balancing interface                │ RS485                        │
-  │ Group load balancing max current              │ 0A                           │
-  │ Group load balancing role                     │ Follower                     │
-  │ LED intensity manual                          │ 22                           │
-  │ LED intensity max                             │ 100                          │
-  │ LED intensity min                             │ 1                            │
-  │ LED intensity mode                            │ Fixed                        │
-  │ Local REST API access mode                    │ ReadWrite                    │
-  │ Local REST API allowed                        │ ✅                           │
-  │ Local REST API enabled                        │ ✅                           │
-  │ Local smart charging allowed                  │ ✅                           │
-  │ Modbus server access mode                     │ ReadOnly                     │
-  │ Modbus server allowed                         │ ✅                           │
-  │ Modbus server enabled                         │ ❌                           │
-  │ Phase rotation                                │ RST                          │
-  │ Power limit input DI1 inverse                 │ ❌                           │
-  │ Power limit input DI1 limit                   │ 0A                           │
-  │ Power limit input DI2 inverse                 │ ❌                           │
-  │ Power limit input DI2 limit                   │ 6A                           │
-  │ Power limit input enabled                     │ ❌                           │
-  │ Predefined CPO name                           │                              │
-  │ Scheduled charging allowed                    │ ✅                           │
-  │ Scheduled charging enabled                    │ ❌                           │
-  │ SECC OCPP active                              │ ❌                           │
-  │ SECC OCPP URI                                 │                              │
-  │ Session manager charge without authentication │ ✅                           │
-  │ Solar charging allowed                        │ ✅                           │
-  │ Solar charging enabled                        │ ❌                           │
-  │ Solar charging mode                           │ MaxSolar                     │
-  │ Solar charging source parameters              │ address: redacted-host       │
-  │ Solar charging source                         │ homewizard                   │
-  │ Time zone                                     │ Europe/Amsterdam             │
-  │ User defined charge limit current allowed     │ ✅                           │
-  │ User defined charge limit current             │ 16A                          │
-  │ User defined household power limit allowed    │ ✅                           │
-  │ User defined household power limit enabled    │ ❌                           │
-  │ User defined household power limit source     │ notselected                  │
-  │ User defined household power limit            │ 17.5 kW                      │
-  │ User keep socket locked                       │ ❌                           │
-  │ VDE phase imbalance enabled                   │ ❌                           │
-  │ VDE phase imbalance limit                     │ 12A                          │
-  │ Web IF update helper                          │ ✅                           │
-  ├───────────────────────────────────────────────┼──────────────────────────────┤
-  │ Smart charging mode                           │ Default                      │
-  └───────────────────────────────────────────────┴──────────────────────────────┘
+                          Peblar user configuration                         
+  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┓
+  ┃ Property                                      ┃ Value                  ┃
+  ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━┩
+  │ BOP fallback current                          │ 6000                   │
+  │ BOP HomeWizard address                        │                        │
+  │ BOP source parameters                         │ address: redacted-host │
+  │ BOP source                                    │ homewizard             │
+  │ Buzzer volume                                 │ 4                      │
+  │ Connected phases                              │ 3                      │
+  │ Current control BOP CT type                   │ CTK05-14               │
+  │ Current control BOP enabled                   │ ✅                     │
+  │ Current control BOP fuse rating               │ 25A                    │
+  │ Current control fixed charge current limit    │ 16                     │
+  │ Ground monitoring                             │ ✅                     │
+  │ Group load balancing enabled                  │ ❌                     │
+  │ Group load balancing fallback current         │ 6A                     │
+  │ Group load balancing group ID                 │ 1                      │
+  │ Group load balancing interface                │ RS485                  │
+  │ Group load balancing max current              │ 0A                     │
+  │ Group load balancing role                     │ Follower               │
+  │ LED intensity manual                          │ 22                     │
+  │ LED intensity max                             │ 100                    │
+  │ LED intensity min                             │ 1                      │
+  │ LED intensity mode                            │ Fixed                  │
+  │ Local REST API access mode                    │ ReadWrite              │
+  │ Local REST API allowed                        │ ✅                     │
+  │ Local REST API enabled                        │ ✅                     │
+  │ Local smart charging allowed                  │ ✅                     │
+  │ Modbus server access mode                     │ ReadOnly               │
+  │ Modbus server allowed                         │ ✅                     │
+  │ Modbus server enabled                         │ ❌                     │
+  │ Phase rotation                                │ RST                    │
+  │ Power limit input DI1 inverse                 │ ❌                     │
+  │ Power limit input DI1 limit                   │ 0A                     │
+  │ Power limit input DI2 inverse                 │ ❌                     │
+  │ Power limit input DI2 limit                   │ 6A                     │
+  │ Power limit input enabled                     │ ❌                     │
+  │ Predefined CPO name                           │                        │
+  │ Scheduled charging allowed                    │ ✅                     │
+  │ Scheduled charging enabled                    │ ❌                     │
+  │ SECC OCPP active                              │ ❌                     │
+  │ SECC OCPP URI                                 │                        │
+  │ Session manager charge without authentication │ ✅                     │
+  │ Solar charging allowed                        │ ✅                     │
+  │ Solar charging enabled                        │ ❌                     │
+  │ Solar charging mode                           │ MaxSolar               │
+  │ Solar charging source parameters              │ address: redacted-host │
+  │ Solar charging source                         │ homewizard             │
+  │ Time zone                                     │ Europe/Amsterdam       │
+  │ User defined charge limit current allowed     │ ✅                     │
+  │ User defined charge limit current             │ 16A                    │
+  │ User defined household power limit allowed    │ ✅                     │
+  │ User defined household power limit enabled    │ ❌                     │
+  │ User defined household power limit source     │ notselected            │
+  │ User defined household power limit            │ 17.5 kW                │
+  │ User keep socket locked                       │ ❌                     │
+  │ VDE phase imbalance enabled                   │ ❌                     │
+  │ VDE phase imbalance limit                     │ 12A                    │
+  │ Web IF update helper                          │ ✅                     │
+  ├───────────────────────────────────────────────┼────────────────────────┤
+  │ Smart charging mode                           │ Default                │
+  └───────────────────────────────────────────────┴────────────────────────┘
   
   '''
 # ---

--- a/tests/test_peblar.py
+++ b/tests/test_peblar.py
@@ -927,3 +927,31 @@ async def test_no_relogin_without_a_stored_password() -> None:
         async with Peblar(host=HOST) as peblar:
             with pytest.raises(PeblarAuthenticationError):
                 await peblar.user_configuration()
+
+
+def test_user_configuration_parses_parameter_blobs() -> None:
+    """Test JSON encoded parameter blobs come back as dictionaries.
+
+    The charger sends these as JSON encoded strings and
+    ``__pre_deserialize__`` unpacks them, so both have to be annotated as
+    mappings. Annotating one as ``str`` handed back the repr of a dict.
+    """
+    config = PeblarUserConfiguration.from_json(
+        load_fixture("user_configuration.json"),
+    )
+    assert config.bop_source_parameters == {"address": "redacted-host"}
+    assert config.solar_charging_source_parameters == {"address": "redacted-host"}
+    assert config.bop_source_parameters.get("address") == "redacted-host"
+
+
+def test_user_configuration_empty_parameter_blobs() -> None:
+    """Test an empty parameter blob still lands as an empty dictionary."""
+    config = PeblarUserConfiguration.from_json(
+        patched_fixture(
+            "user_configuration.json",
+            BopSourceParameters="",
+            SolarChargingSourceParameters="",
+        ),
+    )
+    assert config.bop_source_parameters == {}
+    assert config.solar_charging_source_parameters == {}


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

`__pre_deserialize__` decodes both `BopSourceParameters` and `SolarChargingSourceParameters` from their JSON encoded strings into dictionaries, but `bop_source_parameters` was annotated as `str` while its sibling was annotated as `dict[str, Any]`. So mashumaro turned the decoded dictionary straight back into a string, and callers got the Python repr of a dict:

```
bop_source_parameters : "{'address': 'redacted-host'}"   str
solar_..._parameters  : {'address': 'redacted-host'}     dict
```

Annotating it as `dict[str, Any]` makes it behave like the solar equivalent, so the values are actually reachable. The only other change is the CLI config snapshot, where the BOP row now renders the same way the solar row already did.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
