### PR TITLE
Handle rate limiting and surface charger error messages

### DIFF
--- a/src/peblar/cli/__init__.py
+++ b/src/peblar/cli/__init__.py
@@ -36,6 +36,7 @@ from peblar.exceptions import (
     PeblarBadRequestError,
     PeblarConnectionError,
     PeblarError,
+    PeblarRateLimitError,
     PeblarUnsupportedFirmwareVersionError,
 )
 from peblar.models import (
@@ -188,7 +189,7 @@ async def meterhistory_fetch_data(
             stop=normalized_stop,
         )
     except PeblarBadRequestError as exc:
-        console.print(f"❌[red]Bad request: {exc}")
+        console.print(f"❌[red]{exc}")
         raise typer.Exit(code=1) from exc
     tokens = await peblar.rfid_tokens()
     return normalized_start, normalized_stop, history, tokens
@@ -520,6 +521,26 @@ def connection_error_handler(_: PeblarConnectionError) -> None:
         message,
         expand=False,
         title="Connection error",
+        border_style="red bold",
+    )
+    console.print(panel)
+    sys.exit(1)
+
+
+@cli.error_handler(PeblarRateLimitError)
+def rate_limit_error_handler(_: PeblarRateLimitError) -> None:
+    """Handle rate limit errors."""
+    message = """
+    The Peblar charger is refusing requests because too many were made in a
+    short time. The local REST API allows 5 requests per second, shared
+    between everything talking to the charger.
+
+    Give it a moment and try again.
+    """
+    panel = Panel(
+        message,
+        expand=False,
+        title="Rate limited",
         border_style="red bold",
     )
     console.print(panel)

--- a/src/peblar/cli/__init__.py
+++ b/src/peblar/cli/__init__.py
@@ -189,7 +189,9 @@ async def meterhistory_fetch_data(
             stop=normalized_stop,
         )
     except PeblarBadRequestError as exc:
-        console.print(f"❌[red]{exc}")
+        # markup=False: the message carries the charger's own text, and Rich
+        # would silently eat any part of it that looks like a tag.
+        console.print(f"❌ {exc}", style="red", markup=False)
         raise typer.Exit(code=1) from exc
     tokens = await peblar.rfid_tokens()
     return normalized_start, normalized_stop, history, tokens

--- a/src/peblar/exceptions.py
+++ b/src/peblar/exceptions.py
@@ -25,5 +25,13 @@ class PeblarBadRequestError(PeblarResponseError):
     """Peblar bad request (HTTP 400) exception."""
 
 
+class PeblarRateLimitError(PeblarResponseError):
+    """Peblar rate limit exception.
+
+    The local REST API allows 5 requests per second, with bursts up to 10.
+    Exceeding that gets you an HTTP 429 until the charger calms down again.
+    """
+
+
 class PeblarUnsupportedFirmwareVersionError(PeblarError):
     """Peblar unsupported version exception."""

--- a/src/peblar/peblar.py
+++ b/src/peblar/peblar.py
@@ -114,6 +114,8 @@ class Peblar:
 
         # The body is read before the status is checked, so a failing
         # request can still tell us what the charger complained about.
+        # Decoding never raises: an undecodable body must still come out
+        # as a PeblarError, not a UnicodeDecodeError.
         content = ""
         try:
             async with asyncio.timeout(self.request_timeout):
@@ -123,7 +125,7 @@ class Peblar:
                     headers={"Content-Type": "application/json"},
                     data=data.to_json() if data else None,
                 )
-                content = await response.text()
+                content = await response.text(errors="replace")
                 response.raise_for_status()
         except TimeoutError as exception:
             msg = "Timeout occurred while connecting to the Peblar charger"
@@ -488,6 +490,8 @@ class PeblarApi:
 
         # The body is read before the status is checked, so a failing
         # request can still tell us what the charger complained about.
+        # Decoding never raises: an undecodable body must still come out
+        # as a PeblarError, not a UnicodeDecodeError.
         content = ""
         try:
             async with asyncio.timeout(self.request_timeout):
@@ -500,7 +504,7 @@ class PeblarApi:
                     },
                     data=data.to_json() if data else None,
                 )
-                content = await response.text()
+                content = await response.text(errors="replace")
                 response.raise_for_status()
         except TimeoutError as exception:
             msg = "Timeout occurred while connecting to the Peblar charger API"

--- a/src/peblar/peblar.py
+++ b/src/peblar/peblar.py
@@ -25,6 +25,7 @@ from .exceptions import (
     PeblarConnectionError,
     PeblarConnectionTimeoutError,
     PeblarError,
+    PeblarRateLimitError,
 )
 from .models import (
     BaseModel,
@@ -50,6 +51,7 @@ from .models import (
     PeblarUserConfiguration,
     PeblarVersions,
 )
+from .utils import build_error_message
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Coroutine
@@ -89,7 +91,7 @@ class Peblar:
         self.url = URL.build(scheme="http", host=self.host, path="/api/v1/")
 
     @retry(
-        retry=retry_if_exception_type(PeblarConnectionError),
+        retry=retry_if_exception_type((PeblarConnectionError, PeblarRateLimitError)),
         stop=stop_after_attempt(3),
         wait=wait_exponential(),
         reraise=True,
@@ -110,6 +112,9 @@ class Peblar:
             )
             self._close_session = True
 
+        # The body is read before the status is checked, so a failing
+        # request can still tell us what the charger complained about.
+        content = ""
         try:
             async with asyncio.timeout(self.request_timeout):
                 response = await self.session.request(
@@ -118,13 +123,7 @@ class Peblar:
                     headers={"Content-Type": "application/json"},
                     data=data.to_json() if data else None,
                 )
-                if response.status == 400:
-                    body = await response.text()
-                    try:
-                        msg = orjson.loads(body) if body else "Bad request"
-                    except orjson.JSONDecodeError:
-                        msg = body or "Bad request"
-                    raise PeblarBadRequestError(msg)
+                content = await response.text()
                 response.raise_for_status()
         except TimeoutError as exception:
             msg = "Timeout occurred while connecting to the Peblar charger"
@@ -143,9 +142,21 @@ class Peblar:
                         uri, method=method, data=data, _relogged_in=True
                     )
                 msg = "Authentication error. Provided password is invalid."
-                raise PeblarAuthenticationError(msg) from exception
+                raise PeblarAuthenticationError(
+                    build_error_message(msg, content)
+                ) from exception
+            if exception.status == 429:
+                msg = "Rate limit exceeded while communicating to the Peblar charger"
+                raise PeblarRateLimitError(
+                    build_error_message(msg, content)
+                ) from exception
+            if exception.status == 400:
+                msg = "Bad request sent to the Peblar charger"
+                raise PeblarBadRequestError(
+                    build_error_message(msg, content)
+                ) from exception
             msg = "Error occurred while communicating to the Peblar charger"
-            raise PeblarError(msg) from exception
+            raise PeblarError(build_error_message(msg, content)) from exception
         except (
             ClientError,
             socket.gaierror,
@@ -153,7 +164,7 @@ class Peblar:
             msg = "Error occurred while communicating to the Peblar charger"
             raise PeblarConnectionError(msg) from exception
 
-        return await response.text()
+        return content
 
     async def login(self, *, password: str) -> None:
         """Log in to the Peblar charger.
@@ -455,7 +466,7 @@ class PeblarApi:
         self.url = URL.build(scheme="http", host=self.host, path="/api/wlac/v1/")
 
     @retry(
-        retry=retry_if_exception_type(PeblarConnectionError),
+        retry=retry_if_exception_type((PeblarConnectionError, PeblarRateLimitError)),
         stop=stop_after_attempt(3),
         wait=wait_exponential(),
         reraise=True,
@@ -475,6 +486,9 @@ class PeblarApi:
             )
             self._close_session = True
 
+        # The body is read before the status is checked, so a failing
+        # request can still tell us what the charger complained about.
+        content = ""
         try:
             async with asyncio.timeout(self.request_timeout):
                 response = await self.session.request(
@@ -486,13 +500,7 @@ class PeblarApi:
                     },
                     data=data.to_json() if data else None,
                 )
-                if response.status == 400:
-                    body = await response.text()
-                    try:
-                        msg = orjson.loads(body) if body else "Bad request"
-                    except orjson.JSONDecodeError:
-                        msg = body or "Bad request"
-                    raise PeblarBadRequestError(msg)
+                content = await response.text()
                 response.raise_for_status()
         except TimeoutError as exception:
             msg = "Timeout occurred while connecting to the Peblar charger API"
@@ -509,9 +517,23 @@ class PeblarApi:
                         uri, method=method, data=data, _refreshed=True
                     )
                 msg = "Authentication error. API token is invalid or expired."
-                raise PeblarAuthenticationError(msg) from exception
+                raise PeblarAuthenticationError(
+                    build_error_message(msg, content)
+                ) from exception
+            if exception.status == 429:
+                msg = (
+                    "Rate limit exceeded while communicating to the Peblar charger API"
+                )
+                raise PeblarRateLimitError(
+                    build_error_message(msg, content)
+                ) from exception
+            if exception.status == 400:
+                msg = "Bad request sent to the Peblar charger API"
+                raise PeblarBadRequestError(
+                    build_error_message(msg, content)
+                ) from exception
             msg = "Error occurred while communicating to the Peblar charger API"
-            raise PeblarError(msg) from exception
+            raise PeblarError(build_error_message(msg, content)) from exception
         except (
             ClientError,
             socket.gaierror,
@@ -519,7 +541,7 @@ class PeblarApi:
             msg = "Error occurred while communicating to the Peblar charger API"
             raise PeblarConnectionError(msg) from exception
 
-        return await response.text()
+        return content
 
     async def ev_interface(
         self,

--- a/src/peblar/utils.py
+++ b/src/peblar/utils.py
@@ -2,6 +2,7 @@
 
 from functools import lru_cache
 
+import orjson
 from awesomeversion import AwesomeVersion
 
 
@@ -9,3 +10,25 @@ from awesomeversion import AwesomeVersion
 def get_awesome_version(version: str) -> AwesomeVersion:
     """Return a cached AwesomeVersion object."""
     return AwesomeVersion(version)
+
+
+def build_error_message(message: str, content: str) -> str:
+    """Enrich an error message with the one the charger sent along.
+
+    Peblar wraps errors in a JSON object holding a `statusmsg` field. Not
+    every response follows that shape, so anything else is dropped and the
+    caller is left with just the generic message.
+    """
+    try:
+        payload = orjson.loads(content)
+    except orjson.JSONDecodeError:
+        return message
+
+    if not isinstance(payload, dict):
+        return message
+
+    reason = payload.get("statusmsg") or payload.get("StatusMsg")
+    if not isinstance(reason, str) or not reason:
+        return message
+
+    return f"{message}: {reason}"

--- a/tests/cli/__snapshots__/test_cli.ambr
+++ b/tests/cli/__snapshots__/test_cli.ambr
@@ -325,6 +325,20 @@
   
   '''
 # ---
+# name: test_rate_limit_error_handler
+  '''
+  ╭─────────────────────────────── Rate limited ────────────────────────────────╮
+  │                                                                             │
+  │     The Peblar charger is refusing requests because too many were made in a │
+  │     short time. The local REST API allows 5 requests per second, shared     │
+  │     between everything talking to the charger.                              │
+  │                                                                             │
+  │     Give it a moment and try again.                                         │
+  │                                                                             │
+  ╰─────────────────────────────────────────────────────────────────────────────╯
+  
+  '''
+# ---
 # name: test_system
   '''
                  Peblar charger system status               

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -14,6 +14,7 @@ from typer.testing import CliRunner
 from peblar.cli import cli
 from peblar.exceptions import (
     PeblarAuthenticationError,
+    PeblarRateLimitError,
     PeblarUnsupportedFirmwareVersionError,
 )
 from peblar.models import (
@@ -342,5 +343,17 @@ def test_unsupported_firmware_error_handler(
     handler = cli.error_handlers[PeblarUnsupportedFirmwareVersionError]
     with pytest.raises(SystemExit) as exc_info:
         handler(PeblarUnsupportedFirmwareVersionError("too old"))
+    assert exc_info.value.code == 1
+    assert capsys.readouterr().out == snapshot
+
+
+def test_rate_limit_error_handler(
+    capsys: pytest.CaptureFixture[str],
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Rate limit error handler prints a panel and exits with 1."""
+    handler = cli.error_handlers[PeblarRateLimitError]
+    with pytest.raises(SystemExit) as exc_info:
+        handler(PeblarRateLimitError("slow down"))
     assert exc_info.value.code == 1
     assert capsys.readouterr().out == snapshot

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -14,6 +14,7 @@ from typer.testing import CliRunner
 from peblar.cli import cli
 from peblar.exceptions import (
     PeblarAuthenticationError,
+    PeblarBadRequestError,
     PeblarRateLimitError,
     PeblarUnsupportedFirmwareVersionError,
 )
@@ -357,3 +358,21 @@ def test_rate_limit_error_handler(
         handler(PeblarRateLimitError("slow down"))
     assert exc_info.value.code == 1
     assert capsys.readouterr().out == snapshot
+
+
+def test_bad_request_message_survives_rich_markup(
+    runner: CliRunner,
+) -> None:
+    """Charger error text is printed verbatim, tags and all.
+
+    The message carries the charger's own `statusmsg`, so anything in it
+    that looks like Rich markup must not be swallowed on the way out.
+    """
+    reason = "limit [/] rejected [bold] see [link=http://x]docs[/link]"
+    mock_cls = _mock_peblar(login=None)
+    mock_cls.return_value.__aenter__.return_value.meter_history.side_effect = (
+        PeblarBadRequestError(f"Bad request sent to the Peblar charger: {reason}")
+    )
+    exit_code, output = _invoke(runner, ["meterhistory", *_AUTH], mock_cls)
+    assert exit_code == 1
+    assert reason in output

--- a/tests/test_peblar.py
+++ b/tests/test_peblar.py
@@ -1057,3 +1057,45 @@ async def test_authentication_error_includes_charger_message() -> None:
 def test_build_error_message(content: str, expected: str) -> None:
     """Test error bodies are only used when they carry a usable message."""
     assert build_error_message("Boom", content) == expected
+
+
+@pytest.mark.parametrize("status", [400, 401, 429, 500])
+async def test_undecodable_error_body_still_maps_to_a_peblar_error(
+    status: int,
+) -> None:
+    """Test a body that is not valid UTF-8 does not escape the error mapping.
+
+    The body is read before the status is checked, so a charger answering
+    an error with a mangled body must still raise a PeblarError rather
+    than a UnicodeDecodeError nobody is catching.
+    """
+    with aioresponses() as mocked:
+        for _ in range(3):
+            mocked.get(
+                API_SYSTEM_URL,
+                status=status,
+                body=b"\xff\xfe not utf-8 \x80",
+                content_type="application/json",
+            )
+        async with PeblarApi(host=HOST, token="t") as api:
+            with pytest.raises(PeblarError):
+                await api.system()
+
+
+async def test_undecodable_success_body_is_replaced_not_raised() -> None:
+    """Test undecodable bytes in a successful body do not blow up the read."""
+    with aioresponses() as mocked:
+        mocked.get(
+            API_SYSTEM_URL,
+            status=200,
+            body=b'{"ActiveErrorCodes": [], "ActiveWarningCodes": [],'
+            b'"CellularSignalStrength": null, "FirmwareVersion": "1.9.2\xff",'
+            b'"Force1PhaseAllowed": true, "PhaseCount": 3, "ProductPn": "p",'
+            b'"ProductSn": "s", "Uptime": 1, "WlanSignalStrength": null}',
+            content_type="application/json",
+        )
+        async with PeblarApi(host=HOST, token="t") as api:
+            system = await api.system()
+
+    assert system.phase_count == 3
+    assert system.firmware_version.startswith("1.9.2")

--- a/tests/test_peblar.py
+++ b/tests/test_peblar.py
@@ -19,9 +19,11 @@ from peblar.const import (
 )
 from peblar.exceptions import (
     PeblarAuthenticationError,
+    PeblarBadRequestError,
     PeblarConnectionError,
     PeblarConnectionTimeoutError,
     PeblarError,
+    PeblarRateLimitError,
 )
 from peblar.models import (
     PeblarMeter,
@@ -32,6 +34,7 @@ from peblar.models import (
     PeblarVersions,
 )
 from peblar.peblar import PeblarApi
+from peblar.utils import build_error_message
 from tests import load_fixture
 
 HOST = "example.com"
@@ -955,3 +958,102 @@ def test_user_configuration_empty_parameter_blobs() -> None:
     )
     assert config.bop_source_parameters == {}
     assert config.solar_charging_source_parameters == {}
+
+
+# ---------------------------------------------------------------------------
+# Rate limiting and charger supplied error messages
+# ---------------------------------------------------------------------------
+async def test_rate_limit_retries_and_raises() -> None:
+    """Test a persistent HTTP 429 is retried and then surfaces."""
+    with aioresponses() as mocked:
+        for _ in range(3):
+            mocked.get(SYSTEM_INFO_URL, status=429, body="", content_type="text/plain")
+        async with Peblar(host=HOST) as peblar:
+            with pytest.raises(PeblarRateLimitError, match="Rate limit exceeded"):
+                await peblar.system_information()
+
+
+async def test_rate_limit_then_success() -> None:
+    """Test a single HTTP 429 is retried and then succeeds."""
+    with aioresponses() as mocked:
+        mocked.get(SYSTEM_INFO_URL, status=429, body="", content_type="text/plain")
+        mocked.get(
+            SYSTEM_INFO_URL, status=200, body=load_fixture("system_information.json")
+        )
+        async with Peblar(host=HOST) as peblar:
+            info = await peblar.system_information()
+    assert info.product_vendor_name == "Peblar"
+
+
+async def test_api_rate_limit() -> None:
+    """Test the local REST API surfaces HTTP 429 as a rate limit error."""
+    with aioresponses() as mocked:
+        for _ in range(3):
+            mocked.get(API_METER_URL, status=429, body="", content_type="text/plain")
+        async with PeblarApi(host=HOST, token="t") as api:
+            with pytest.raises(PeblarRateLimitError, match="Rate limit exceeded"):
+                await api.meter()
+
+
+async def test_error_response_includes_charger_message() -> None:
+    """Test the charger's own error message ends up in the exception."""
+    with aioresponses() as mocked:
+        mocked.get(
+            API_SYSTEM_URL,
+            status=500,
+            body=orjson.dumps({"statusmsg": "An internal server error occurred"}),
+        )
+        async with PeblarApi(host=HOST, token="t") as api:
+            with pytest.raises(PeblarError, match="An internal server error occurred"):
+                await api.system()
+
+
+async def test_error_response_without_message() -> None:
+    """Test a non-JSON error body leaves the generic message intact."""
+    with aioresponses() as mocked:
+        mocked.get(API_SYSTEM_URL, status=500, body="oops", content_type="text/plain")
+        async with PeblarApi(host=HOST, token="t") as api:
+            with pytest.raises(PeblarError, match="Error occurred while communicating"):
+                await api.system()
+
+
+async def test_bad_request_includes_charger_message() -> None:
+    """Test a rejected request carries the charger's reason along."""
+    with aioresponses() as mocked:
+        mocked.patch(
+            API_EV_URL,
+            status=400,
+            body=orjson.dumps({"statusmsg": "ChargeCurrentLimit out of range"}),
+        )
+        async with PeblarApi(host=HOST, token="t") as api:
+            with pytest.raises(
+                PeblarBadRequestError, match="ChargeCurrentLimit out of range"
+            ):
+                await api.ev_interface(charge_current_limit=99999)
+
+
+async def test_authentication_error_includes_charger_message() -> None:
+    """Test an unauthorized response carries the charger's message along."""
+    with aioresponses() as mocked:
+        mocked.post(LOGIN_URL, status=401, body=orjson.dumps({"statusmsg": "Nope"}))
+        async with Peblar(host=HOST) as peblar:
+            with pytest.raises(PeblarAuthenticationError, match="Nope"):
+                await peblar.login(password="wrong")
+
+
+@pytest.mark.parametrize(
+    ("content", "expected"),
+    [
+        ('{"statusmsg": "Nope"}', "Boom: Nope"),
+        ('{"StatusMsg": "Nope"}', "Boom: Nope"),
+        ('{"statusmsg": ""}', "Boom"),
+        ('{"statusmsg": 42}', "Boom"),
+        ("{}", "Boom"),
+        ("[]", "Boom"),
+        ("not json", "Boom"),
+        ("", "Boom"),
+    ],
+)
+def test_build_error_message(content: str, expected: str) -> None:
+    """Test error bodies are only used when they carry a usable message."""
+    assert build_error_message("Boom", content) == expected


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Three related things in the request layer.

Peblar rate limits the local REST API to 5 requests per second with bursts up to 10, and answers with HTTP 429 when you go over. That was landing as a generic `PeblarError` with no retry. It now raises a dedicated `PeblarRateLimitError` and joins `PeblarConnectionError` in the retry policy, so a burst backs off and recovers instead of failing outright.

The charger returns its own reason in a `statusmsg` field, which we threw away. So a rejected charge current limit read as "Error occurred while communicating to the Peblar charger API" instead of "ChargeCurrentLimit out of range". The body is now read before the status is checked, and `build_error_message` appends the charger's message when there is one.

That also folds the HTTP 400 handling from #418 into the same path. It ran inline ahead of `raise_for_status()` and handed the parsed JSON object to the exception, so `str(exc)` produced a dict repr. It is now a branch alongside 401 and 429 going through the same builder, which is why the meterhistory command no longer prefixes its own "Bad request" onto a message that already says it.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Follows up on #418.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
