### PR TITLE
Add fields reported by newer firmware

### DIFF
--- a/src/peblar/cli/__init__.py
+++ b/src/peblar/cli/__init__.py
@@ -97,9 +97,10 @@ def format_volts(volts: int | None) -> str:
 def convert_to_string(value: object) -> str:
     """Convert a value to a string.
 
-    Anything the charger did not report becomes "N/A" rather than the
-    literal "None", which is what older firmware leaves behind for the
-    fields it does not know about.
+    A field older firmware never reports arrives as None and renders as
+    "N/A" rather than the literal "None". Not every absent value arrives
+    that way though: the parameter blobs fall back to an empty dict, which
+    renders as an empty cell.
     """
     if value is None:
         return "N/A"

--- a/src/peblar/cli/__init__.py
+++ b/src/peblar/cli/__init__.py
@@ -1259,6 +1259,9 @@ async def system_information(
     table.add_row("Hardware has BOP", convert_to_string(info.hardware_has_bop))
     table.add_row("Hardware has buzzer", convert_to_string(info.hardware_has_buzzer))
     table.add_row(
+        "Hardware has dual socket", convert_to_string(info.hardware_has_dual_socket)
+    )
+    table.add_row(
         "Hardware has Eichrecht laser marking",
         convert_to_string(info.hardware_has_eichrecht_laser_marking),
     )
@@ -1271,9 +1274,14 @@ async def system_information(
         "Hardware has meter display", convert_to_string(info.hardware_has_meter_display)
     )
     table.add_row("Hardware has meter", convert_to_string(info.hardware_has_meter))
+    table.add_row(
+        "Hardware has 4-pole relay",
+        convert_to_string(info.hardware_has_four_pole_relay),
+    )
     table.add_row("Hardware has PLC", convert_to_string(info.hardware_has_plc))
     table.add_row("Hardware has RFID", convert_to_string(info.hardware_has_rfid))
     table.add_row("Hardware has RS485", convert_to_string(info.hardware_has_rs485))
+    table.add_row("Hardware has shutter", convert_to_string(info.hardware_has_shutter))
     table.add_row("Hardware has socket", convert_to_string(info.hardware_has_socket))
     table.add_row("Hardware has TPM", convert_to_string(info.hardware_has_tpm))
     table.add_row("Hardware has WLAN", convert_to_string(info.hardware_has_wlan))
@@ -1282,10 +1290,14 @@ async def system_information(
         "Hardware one or three phase",
         convert_to_string(info.hardware_one_or_three_phase),
     )
+    table.add_row(
+        "Hardware UK compliant", convert_to_string(info.hardware_uk_compliant)
+    )
     table.add_row("Hostname", info.hostname)
     table.add_row("Mainboard part number", info.mainboard_part_number)
     table.add_row("Mainboard serial number", info.mainboard_serial_number)
     table.add_row("Meter firmware version", info.meter_firmware_version)
+    table.add_row("NOR flash", convert_to_string(info.nor_flash))
     table.add_row("Product model name", info.product_model_name)
     table.add_row("Product number", info.product_number)
     table.add_row("Product serial number", info.product_serial_number)
@@ -1356,6 +1368,9 @@ async def user_configuration(  # pylint: disable=too-many-statements
     )
     table.add_row("BOP source", config.bop_source)
     table.add_row("Buzzer volume", convert_to_string(config.buzzer_volume))
+    table.add_row(
+        "Connect hub visibility", convert_to_string(config.connect_hub_visibility)
+    )
     table.add_row("Connected phases", convert_to_string(config.connected_phases))
     table.add_row("Current control BOP CT type", config.current_control_bop_ct_type)
     table.add_row(
@@ -1370,6 +1385,7 @@ async def user_configuration(  # pylint: disable=too-many-statements
         "Current control fixed charge current limit",
         convert_to_string(config.current_control_fixed_charge_current_limit),
     )
+    table.add_row("Custom customer ID", convert_to_string(config.custom_customer_id))
     table.add_row("Ground monitoring", convert_to_string(config.ground_monitoring))
     table.add_row(
         "Group load balancing enabled",
@@ -1391,6 +1407,10 @@ async def user_configuration(  # pylint: disable=too-many-statements
         f"{config.group_load_balancing_max_current}A",
     )
     table.add_row("Group load balancing role", config.group_load_balancing_role)
+    table.add_row(
+        "ISO 15118 communication enabled",
+        convert_to_string(config.iso15118_communication_enabled),
+    )
     table.add_row(
         "LED intensity manual", convert_to_string(config.led_intensity_manual)
     )
@@ -1435,6 +1455,8 @@ async def user_configuration(  # pylint: disable=too-many-statements
         "Power limit input enabled", convert_to_string(config.power_limit_input_enabled)
     )
     table.add_row("Predefined CPO name", config.predefined_cpo_name)
+    table.add_row("SBO allowed", convert_to_string(config.sbo_allowed))
+    table.add_row("SBO enabled", convert_to_string(config.sbo_enabled))
     table.add_row(
         "Scheduled charging allowed",
         convert_to_string(config.scheduled_charging_allowed),
@@ -1445,6 +1467,9 @@ async def user_configuration(  # pylint: disable=too-many-statements
     )
     table.add_row("SECC OCPP active", convert_to_string(config.secc_ocpp_active))
     table.add_row("SECC OCPP URI", config.secc_ocpp_uri)
+    table.add_row(
+        "Session download allowed", convert_to_string(config.session_download_allowed)
+    )
     table.add_row(
         "Session manager charge without authentication",
         convert_to_string(config.session_manager_charge_without_authentication),
@@ -1481,6 +1506,10 @@ async def user_configuration(  # pylint: disable=too-many-statements
     table.add_row(
         "User defined household power limit source",
         config.user_defined_household_power_limit_source,
+    )
+    table.add_row(
+        "User defined household power limit source parameters",
+        convert_to_string(config.user_defined_household_power_limit_source_parameters),
     )
     table.add_row(
         "User defined household power limit",

--- a/src/peblar/cli/__init__.py
+++ b/src/peblar/cli/__init__.py
@@ -95,11 +95,18 @@ def format_volts(volts: int | None) -> str:
 
 
 def convert_to_string(value: object) -> str:
-    """Convert a value to a string."""
+    """Convert a value to a string.
+
+    Anything the charger did not report becomes "N/A" rather than the
+    literal "None", which is what older firmware leaves behind for the
+    fields it does not know about.
+    """
+    if value is None:
+        return "N/A"
     if isinstance(value, bool):
         return "✅" if value else "❌"
     if isinstance(value, dict):
-        return "".join(f"{key}: {value}" for key, value in value.items())
+        return ", ".join(f"{key}: {item}" for key, item in value.items())
     return str(value)
 
 

--- a/src/peblar/models.py
+++ b/src/peblar/models.py
@@ -215,8 +215,14 @@ class PeblarSystemInformation(BaseModel):
     hardware_firmware_compatibility: str = field(
         metadata=field_options(alias="HwFwCompat")
     )
+    hardware_has_four_pole_relay: bool | None = field(
+        default=None, metadata=field_options(alias="HwHas4pRelay")
+    )
     hardware_has_bop: bool = field(metadata=field_options(alias="HwHasBop"))
     hardware_has_buzzer: bool = field(metadata=field_options(alias="HwHasBuzzer"))
+    hardware_has_dual_socket: bool | None = field(
+        default=None, metadata=field_options(alias="HwHasDualSocket")
+    )
     hardware_has_eichrecht_laser_marking: bool = field(
         metadata=field_options(alias="HwHasEichrechtLaserMarking")
     )
@@ -230,12 +236,18 @@ class PeblarSystemInformation(BaseModel):
     hardware_has_plc: bool = field(metadata=field_options(alias="HwHasPlc"))
     hardware_has_rfid: bool = field(metadata=field_options(alias="HwHasRfid"))
     hardware_has_rs485: bool = field(metadata=field_options(alias="HwHasRs485"))
+    hardware_has_shutter: bool | None = field(
+        default=None, metadata=field_options(alias="HwHasShutter")
+    )
     hardware_has_socket: bool = field(metadata=field_options(alias="HwHasSocket"))
     hardware_has_tpm: bool = field(metadata=field_options(alias="HwHasTpm"))
     hardware_has_wlan: bool = field(metadata=field_options(alias="HwHasWlan"))
     hardware_max_current: int = field(metadata=field_options(alias="HwMaxCurrent"))
     hardware_one_or_three_phase: int = field(
         metadata=field_options(alias="HwOneOrThreePhase")
+    )
+    hardware_uk_compliant: bool | None = field(
+        default=None, metadata=field_options(alias="HwUKCompliant")
     )
     mainboard_part_number: str = field(metadata=field_options(alias="MainboardPn"))
     mainboard_serial_number: str = field(metadata=field_options(alias="MainboardSn"))
@@ -276,6 +288,9 @@ class PeblarSystemInformation(BaseModel):
         metadata=field_options(alias="MeterCalVGainC")
     )
     meter_firmware_version: str = field(metadata=field_options(alias="MeterFwIdent"))
+    nor_flash: bool | None = field(
+        default=None, metadata=field_options(alias="NorFlash")
+    )
     product_model_name: str = field(metadata=field_options(alias="ProductModelName"))
     product_number: str = field(metadata=field_options(alias="ProductPn"))
     product_serial_number: str = field(metadata=field_options(alias="ProductSn"))
@@ -299,6 +314,9 @@ class PeblarUserConfiguration(BaseModel):
     bop_source_parameters: dict[str, Any] = field(
         metadata=field_options(alias="BopSourceParameters")
     )
+    connect_hub_visibility: bool | None = field(
+        default=None, metadata=field_options(alias="ConnectHubVisibility")
+    )
     connected_phases: int = field(metadata=field_options(alias="ConnectedPhases"))
     current_control_bop_ct_type: str = field(
         metadata=field_options(alias="CurrentCtrlBopCtType")
@@ -311,6 +329,9 @@ class PeblarUserConfiguration(BaseModel):
     )
     current_control_fixed_charge_current_limit: int = field(
         metadata=field_options(alias="CurrentCtrlFixedChargeCurrentLimit")
+    )
+    custom_customer_id: str | None = field(
+        default=None, metadata=field_options(alias="CustomCustomerId")
     )
     ground_monitoring: bool = field(metadata=field_options(alias="GroundMonitoring"))
     group_load_balancing_enabled: bool = field(
@@ -339,6 +360,9 @@ class PeblarUserConfiguration(BaseModel):
     led_intensity_min: int = field(metadata=field_options(alias="HmiLedIntensityMin"))
     led_intensity_mode: LedIntensityMode = field(
         metadata=field_options(alias="HmiLedIntensityMode")
+    )
+    iso15118_communication_enabled: bool | None = field(
+        default=None, metadata=field_options(alias="Iso15118CommunicationEnable")
     )
     local_rest_api_access_mode: AccessMode = field(
         metadata=field_options(alias="LocalRestApiAccessMode")
@@ -378,6 +402,12 @@ class PeblarUserConfiguration(BaseModel):
         metadata=field_options(alias="PowerLimitInputEnable")
     )
     predefined_cpo_name: str = field(metadata=field_options(alias="PredefinedCpoName"))
+    sbo_allowed: bool | None = field(
+        default=None, metadata=field_options(alias="SboAllowed")
+    )
+    sbo_enabled: str | None = field(
+        default=None, metadata=field_options(alias="SboEnabled")
+    )
     scheduled_charging_allowed: bool = field(
         metadata=field_options(alias="ScheduledChargingAllowed")
     )
@@ -386,6 +416,9 @@ class PeblarUserConfiguration(BaseModel):
     )
     secc_ocpp_active: bool = field(metadata=field_options(alias="SeccOcppActive"))
     secc_ocpp_uri: str = field(metadata=field_options(alias="SeccOcppUri"))
+    session_download_allowed: bool | None = field(
+        default=None, metadata=field_options(alias="SessionDownloadAllowed")
+    )
     session_manager_charge_without_authentication: bool = field(
         metadata=field_options(alias="SessionManagerChargeWithoutAuth")
     )
@@ -423,6 +456,10 @@ class PeblarUserConfiguration(BaseModel):
     user_defined_household_power_limit_source: str = field(
         metadata=field_options(alias="UserDefinedHouseholdPowerLimitSource")
     )
+    user_defined_household_power_limit_source_parameters: dict[str, Any] = field(
+        default_factory=dict,
+        metadata=field_options(alias="UserDefinedHouseholdPowerLimitSourceParameters"),
+    )
     user_keep_socket_locked: bool = field(
         metadata=field_options(alias="UserKeepSocketLocked")
     )
@@ -443,10 +480,12 @@ class PeblarUserConfiguration(BaseModel):
     @classmethod
     def __pre_deserialize__(cls, d: dict[Any, Any]) -> dict[Any, Any]:
         """Pre deserialize hook for PeblarUserConfiguration object."""
-        d["SolarChargingSourceParameters"] = orjson.loads(
-            d.get("SolarChargingSourceParameters") or "{}"
-        )
-        d["BopSourceParameters"] = orjson.loads(d.get("BopSourceParameters") or "{}")
+        for key in (
+            "BopSourceParameters",
+            "SolarChargingSourceParameters",
+            "UserDefinedHouseholdPowerLimitSourceParameters",
+        ):
+            d[key] = orjson.loads(d.get(key) or "{}")
         return d
 
     @classmethod

--- a/src/peblar/models.py
+++ b/src/peblar/models.py
@@ -485,7 +485,13 @@ class PeblarUserConfiguration(BaseModel):
             "SolarChargingSourceParameters",
             "UserDefinedHouseholdPowerLimitSourceParameters",
         ):
-            d[key] = orjson.loads(d.get(key) or "{}")
+            # The charger sends these JSON encoded, but tolerate a blob that
+            # is already a mapping so feeding back an earlier result does
+            # not blow up on a second decode.
+            blob = d.get(key)
+            if isinstance(blob, str) or blob is None:
+                blob = orjson.loads(blob or "{}")
+            d[key] = blob
         return d
 
     @classmethod

--- a/tests/cli/__snapshots__/test_cli.ambr
+++ b/tests/cli/__snapshots__/test_cli.ambr
@@ -167,69 +167,76 @@
 # ---
 # name: test_config
   '''
-                          Peblar user configuration                         
-  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┓
-  ┃ Property                                      ┃ Value                  ┃
-  ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━┩
-  │ BOP fallback current                          │ 6000                   │
-  │ BOP HomeWizard address                        │                        │
-  │ BOP source parameters                         │ address: redacted-host │
-  │ BOP source                                    │ homewizard             │
-  │ Buzzer volume                                 │ 4                      │
-  │ Connected phases                              │ 3                      │
-  │ Current control BOP CT type                   │ CTK05-14               │
-  │ Current control BOP enabled                   │ ✅                     │
-  │ Current control BOP fuse rating               │ 25A                    │
-  │ Current control fixed charge current limit    │ 16                     │
-  │ Ground monitoring                             │ ✅                     │
-  │ Group load balancing enabled                  │ ❌                     │
-  │ Group load balancing fallback current         │ 6A                     │
-  │ Group load balancing group ID                 │ 1                      │
-  │ Group load balancing interface                │ RS485                  │
-  │ Group load balancing max current              │ 0A                     │
-  │ Group load balancing role                     │ Follower               │
-  │ LED intensity manual                          │ 22                     │
-  │ LED intensity max                             │ 100                    │
-  │ LED intensity min                             │ 1                      │
-  │ LED intensity mode                            │ Fixed                  │
-  │ Local REST API access mode                    │ ReadWrite              │
-  │ Local REST API allowed                        │ ✅                     │
-  │ Local REST API enabled                        │ ✅                     │
-  │ Local smart charging allowed                  │ ✅                     │
-  │ Modbus server access mode                     │ ReadOnly               │
-  │ Modbus server allowed                         │ ✅                     │
-  │ Modbus server enabled                         │ ❌                     │
-  │ Phase rotation                                │ RST                    │
-  │ Power limit input DI1 inverse                 │ ❌                     │
-  │ Power limit input DI1 limit                   │ 0A                     │
-  │ Power limit input DI2 inverse                 │ ❌                     │
-  │ Power limit input DI2 limit                   │ 6A                     │
-  │ Power limit input enabled                     │ ❌                     │
-  │ Predefined CPO name                           │                        │
-  │ Scheduled charging allowed                    │ ✅                     │
-  │ Scheduled charging enabled                    │ ❌                     │
-  │ SECC OCPP active                              │ ❌                     │
-  │ SECC OCPP URI                                 │                        │
-  │ Session manager charge without authentication │ ✅                     │
-  │ Solar charging allowed                        │ ✅                     │
-  │ Solar charging enabled                        │ ❌                     │
-  │ Solar charging mode                           │ MaxSolar               │
-  │ Solar charging source parameters              │ address: redacted-host │
-  │ Solar charging source                         │ homewizard             │
-  │ Time zone                                     │ Europe/Amsterdam       │
-  │ User defined charge limit current allowed     │ ✅                     │
-  │ User defined charge limit current             │ 16A                    │
-  │ User defined household power limit allowed    │ ✅                     │
-  │ User defined household power limit enabled    │ ❌                     │
-  │ User defined household power limit source     │ notselected            │
-  │ User defined household power limit            │ 17.5 kW                │
-  │ User keep socket locked                       │ ❌                     │
-  │ VDE phase imbalance enabled                   │ ❌                     │
-  │ VDE phase imbalance limit                     │ 12A                    │
-  │ Web IF update helper                          │ ✅                     │
-  ├───────────────────────────────────────────────┼────────────────────────┤
-  │ Smart charging mode                           │ Default                │
-  └───────────────────────────────────────────────┴────────────────────────┘
+                              Peblar user configuration                            
+  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┓
+  ┃ Property                                             ┃ Value                  ┃
+  ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━┩
+  │ BOP fallback current                                 │ 6000                   │
+  │ BOP HomeWizard address                               │                        │
+  │ BOP source parameters                                │ address: redacted-host │
+  │ BOP source                                           │ homewizard             │
+  │ Buzzer volume                                        │ 4                      │
+  │ Connect hub visibility                               │ ✅                     │
+  │ Connected phases                                     │ 3                      │
+  │ Current control BOP CT type                          │ CTK05-14               │
+  │ Current control BOP enabled                          │ ✅                     │
+  │ Current control BOP fuse rating                      │ 25A                    │
+  │ Current control fixed charge current limit           │ 16                     │
+  │ Custom customer ID                                   │                        │
+  │ Ground monitoring                                    │ ✅                     │
+  │ Group load balancing enabled                         │ ❌                     │
+  │ Group load balancing fallback current                │ 6A                     │
+  │ Group load balancing group ID                        │ 1                      │
+  │ Group load balancing interface                       │ RS485                  │
+  │ Group load balancing max current                     │ 0A                     │
+  │ Group load balancing role                            │ Follower               │
+  │ ISO 15118 communication enabled                      │ ❌                     │
+  │ LED intensity manual                                 │ 22                     │
+  │ LED intensity max                                    │ 100                    │
+  │ LED intensity min                                    │ 1                      │
+  │ LED intensity mode                                   │ Fixed                  │
+  │ Local REST API access mode                           │ ReadWrite              │
+  │ Local REST API allowed                               │ ✅                     │
+  │ Local REST API enabled                               │ ✅                     │
+  │ Local smart charging allowed                         │ ✅                     │
+  │ Modbus server access mode                            │ ReadOnly               │
+  │ Modbus server allowed                                │ ✅                     │
+  │ Modbus server enabled                                │ ❌                     │
+  │ Phase rotation                                       │ RST                    │
+  │ Power limit input DI1 inverse                        │ ❌                     │
+  │ Power limit input DI1 limit                          │ 0A                     │
+  │ Power limit input DI2 inverse                        │ ❌                     │
+  │ Power limit input DI2 limit                          │ 6A                     │
+  │ Power limit input enabled                            │ ❌                     │
+  │ Predefined CPO name                                  │                        │
+  │ SBO allowed                                          │ ✅                     │
+  │ SBO enabled                                          │ Enabled                │
+  │ Scheduled charging allowed                           │ ✅                     │
+  │ Scheduled charging enabled                           │ ❌                     │
+  │ SECC OCPP active                                     │ ❌                     │
+  │ SECC OCPP URI                                        │                        │
+  │ Session download allowed                             │ ✅                     │
+  │ Session manager charge without authentication        │ ✅                     │
+  │ Solar charging allowed                               │ ✅                     │
+  │ Solar charging enabled                               │ ❌                     │
+  │ Solar charging mode                                  │ MaxSolar               │
+  │ Solar charging source parameters                     │ address: redacted-host │
+  │ Solar charging source                                │ homewizard             │
+  │ Time zone                                            │ Europe/Amsterdam       │
+  │ User defined charge limit current allowed            │ ✅                     │
+  │ User defined charge limit current                    │ 16A                    │
+  │ User defined household power limit allowed           │ ✅                     │
+  │ User defined household power limit enabled           │ ❌                     │
+  │ User defined household power limit source            │ notselected            │
+  │ User defined household power limit source parameters │                        │
+  │ User defined household power limit                   │ 17.5 kW                │
+  │ User keep socket locked                              │ ❌                     │
+  │ VDE phase imbalance enabled                          │ ❌                     │
+  │ VDE phase imbalance limit                            │ 12A                    │
+  │ Web IF update helper                                 │ ✅                     │
+  ├──────────────────────────────────────────────────────┼────────────────────────┤
+  │ Smart charging mode                                  │ Default                │
+  └──────────────────────────────────────────────────────┴────────────────────────┘
   
   '''
 # ---
@@ -271,24 +278,29 @@
   │ Hardware fixed cable rating          │ 20A                 │
   │ Hardware has BOP                     │ ✅                  │
   │ Hardware has buzzer                  │ ✅                  │
+  │ Hardware has dual socket             │ ❌                  │
   │ Hardware has Eichrecht laser marking │ ❌                  │
   │ Hardware has Ethernet                │ ✅                  │
   │ Hardware has LED                     │ ✅                  │
   │ Hardware has LTE                     │ ❌                  │
   │ Hardware has meter display           │ ✅                  │
   │ Hardware has meter                   │ ✅                  │
+  │ Hardware has 4-pole relay            │ ❌                  │
   │ Hardware has PLC                     │ ❌                  │
   │ Hardware has RFID                    │ ✅                  │
   │ Hardware has RS485                   │ ✅                  │
+  │ Hardware has shutter                 │ ❌                  │
   │ Hardware has socket                  │ ❌                  │
   │ Hardware has TPM                     │ ❌                  │
   │ Hardware has WLAN                    │ ✅                  │
   │ Hardware max current                 │ 16A                 │
   │ Hardware one or three phase          │ 3                   │
+  │ Hardware UK compliant                │ ❌                  │
   │ Hostname                             │ PBLR-0000001        │
   │ Mainboard part number                │ 0000-0000-0000      │
   │ Mainboard serial number              │ 00-00-AAA-000       │
   │ Meter firmware version               │ 3d8966              │
+  │ NOR flash                            │ ✅                  │
   │ Product model name                   │ WLAC1-H11R0WE0ICR00 │
   │ Product number                       │ 0000-0000-0000      │
   │ Product serial number                │ 00-00-AAA-000       │

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -397,12 +397,32 @@ def test_convert_to_string(value: object, expected: str) -> None:
     assert convert_to_string(value) == expected
 
 
+# Every field newer firmware added, so the older firmware tests below drop
+# all of them rather than a sample.
+NEWER_SYSTEM_INFORMATION_KEYS = (
+    "HwHas4pRelay",
+    "HwHasDualSocket",
+    "HwHasShutter",
+    "HwUKCompliant",
+    "NorFlash",
+)
+NEWER_USER_CONFIGURATION_KEYS = (
+    "ConnectHubVisibility",
+    "CustomCustomerId",
+    "Iso15118CommunicationEnable",
+    "SboAllowed",
+    "SboEnabled",
+    "SessionDownloadAllowed",
+    "UserDefinedHouseholdPowerLimitSourceParameters",
+)
+
+
 def test_info_on_older_firmware_shows_no_literal_none(
     runner: CliRunner,
 ) -> None:
     """Older firmware omits fields, and the table must not print "None"."""
     data = orjson.loads(load_fixture("system_information.json"))
-    for key in ("HwHas4pRelay", "HwHasDualSocket", "HwHasShutter", "HwUKCompliant"):
+    for key in NEWER_SYSTEM_INFORMATION_KEYS:
         del data[key]
 
     info = PeblarSystemInformation.from_dict(data)
@@ -410,7 +430,8 @@ def test_info_on_older_firmware_shows_no_literal_none(
     exit_code, output = _invoke(runner, ["info", *_AUTH], mock_cls)
     assert exit_code == 0
     assert "None" not in output
-    assert "N/A" in output
+    # One "N/A" for every field the charger did not report.
+    assert output.count("N/A") == len(NEWER_SYSTEM_INFORMATION_KEYS)
 
 
 def test_config_on_older_firmware_shows_no_literal_none(
@@ -418,7 +439,7 @@ def test_config_on_older_firmware_shows_no_literal_none(
 ) -> None:
     """Older firmware omits settings, and the table must not print "None"."""
     data = orjson.loads(load_fixture("user_configuration.json"))
-    for key in ("ConnectHubVisibility", "Iso15118CommunicationEnable", "SboAllowed"):
+    for key in NEWER_USER_CONFIGURATION_KEYS:
         del data[key]
 
     config = PeblarUserConfiguration.from_dict(data)
@@ -426,3 +447,6 @@ def test_config_on_older_firmware_shows_no_literal_none(
     exit_code, output = _invoke(runner, ["config", *_AUTH], mock_cls)
     assert exit_code == 0
     assert "None" not in output
+    # The parameter blob defaults to an empty dict, not None, so it renders
+    # blank instead of "N/A"; every other absent setting shows "N/A".
+    assert output.count("N/A") == len(NEWER_USER_CONFIGURATION_KEYS) - 1

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -7,11 +7,12 @@ from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import click
+import orjson
 import pytest
 from typer.main import get_command
 from typer.testing import CliRunner
 
-from peblar.cli import cli
+from peblar.cli import cli, convert_to_string
 from peblar.exceptions import (
     PeblarAuthenticationError,
     PeblarBadRequestError,
@@ -376,3 +377,52 @@ def test_bad_request_message_survives_rich_markup(
     exit_code, output = _invoke(runner, ["meterhistory", *_AUTH], mock_cls)
     assert exit_code == 1
     assert reason in output
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, "N/A"),
+        (True, "✅"),
+        (False, "❌"),
+        ({}, ""),
+        ({"address": "meter-1"}, "address: meter-1"),
+        ({"address": "meter-1", "port": 8080}, "address: meter-1, port: 8080"),
+        ("plain", "plain"),
+        (16, "16"),
+    ],
+)
+def test_convert_to_string(value: object, expected: str) -> None:
+    """Values render readably, including absent ones and multi-key blobs."""
+    assert convert_to_string(value) == expected
+
+
+def test_info_on_older_firmware_shows_no_literal_none(
+    runner: CliRunner,
+) -> None:
+    """Older firmware omits fields, and the table must not print "None"."""
+    data = orjson.loads(load_fixture("system_information.json"))
+    for key in ("HwHas4pRelay", "HwHasDualSocket", "HwHasShutter", "HwUKCompliant"):
+        del data[key]
+
+    info = PeblarSystemInformation.from_dict(data)
+    mock_cls = _mock_peblar(login=None, system_information=info)
+    exit_code, output = _invoke(runner, ["info", *_AUTH], mock_cls)
+    assert exit_code == 0
+    assert "None" not in output
+    assert "N/A" in output
+
+
+def test_config_on_older_firmware_shows_no_literal_none(
+    runner: CliRunner,
+) -> None:
+    """Older firmware omits settings, and the table must not print "None"."""
+    data = orjson.loads(load_fixture("user_configuration.json"))
+    for key in ("ConnectHubVisibility", "Iso15118CommunicationEnable", "SboAllowed"):
+        del data[key]
+
+    config = PeblarUserConfiguration.from_dict(data)
+    mock_cls = _mock_peblar(login=None, user_configuration=config)
+    exit_code, output = _invoke(runner, ["config", *_AUTH], mock_cls)
+    assert exit_code == 0
+    assert "None" not in output

--- a/tests/test_peblar.py
+++ b/tests/test_peblar.py
@@ -1185,3 +1185,25 @@ def test_household_power_limit_source_parameters_are_decoded() -> None:
     assert config.user_defined_household_power_limit_source_parameters == {
         "address": "meter-1"
     }
+
+
+@pytest.mark.parametrize(
+    ("blob", "expected"),
+    [
+        ('{"address": "meter-1"}', {"address": "meter-1"}),
+        ({"address": "meter-1"}, {"address": "meter-1"}),
+        ("", {}),
+        (None, {}),
+    ],
+    ids=["encoded", "already-decoded", "empty-string", "null"],
+)
+def test_parameter_blob_shapes(blob: object, expected: dict[str, str]) -> None:
+    """Test the parameter blobs survive every shape the charger sends.
+
+    An already decoded mapping has to pass through untouched, so handing a
+    previously parsed payload back in does not fail on a second decode.
+    """
+    data = orjson.loads(load_fixture("user_configuration.json"))
+    data["BopSourceParameters"] = blob
+    config = PeblarUserConfiguration.from_dict(data)
+    assert config.bop_source_parameters == expected

--- a/tests/test_peblar.py
+++ b/tests/test_peblar.py
@@ -1099,3 +1099,89 @@ async def test_undecodable_success_body_is_replaced_not_raised() -> None:
 
     assert system.phase_count == 3
     assert system.firmware_version.startswith("1.9.2")
+
+
+# ---------------------------------------------------------------------------
+# Fields reported by newer firmware
+# ---------------------------------------------------------------------------
+def test_system_information_newer_firmware_fields() -> None:
+    """Test hardware traits reported by newer firmware are picked up."""
+    info = PeblarSystemInformation.from_json(
+        load_fixture("system_information.json"),
+    )
+    assert info.hardware_has_four_pole_relay is False
+    assert info.hardware_has_dual_socket is False
+    assert info.hardware_has_shutter is False
+    assert info.hardware_uk_compliant is False
+    assert info.nor_flash is True
+
+
+def test_user_configuration_newer_firmware_fields() -> None:
+    """Test settings reported by newer firmware are picked up."""
+    config = PeblarUserConfiguration.from_json(
+        load_fixture("user_configuration.json"),
+    )
+    assert config.connect_hub_visibility is True
+    assert config.custom_customer_id == ""
+    assert config.iso15118_communication_enabled is False
+    assert config.sbo_allowed is True
+    assert config.sbo_enabled == "Enabled"
+    assert config.session_download_allowed is True
+    assert config.user_defined_household_power_limit_source_parameters == {}
+
+
+def test_system_information_older_firmware_omits_new_fields() -> None:
+    """Test firmware that does not report the new traits still parses."""
+    data = orjson.loads(load_fixture("system_information.json"))
+    for key in (
+        "HwHas4pRelay",
+        "HwHasDualSocket",
+        "HwHasShutter",
+        "HwUKCompliant",
+        "NorFlash",
+    ):
+        del data[key]
+
+    info = PeblarSystemInformation.from_dict(data)
+    assert info.hardware_has_four_pole_relay is None
+    assert info.hardware_has_dual_socket is None
+    assert info.hardware_has_shutter is None
+    assert info.hardware_uk_compliant is None
+    assert info.nor_flash is None
+
+
+def test_user_configuration_older_firmware_omits_new_fields() -> None:
+    """Test firmware that does not report the new settings still parses."""
+    data = orjson.loads(load_fixture("user_configuration.json"))
+    for key in (
+        "ConnectHubVisibility",
+        "CustomCustomerId",
+        "Iso15118CommunicationEnable",
+        "SboAllowed",
+        "SboEnabled",
+        "SessionDownloadAllowed",
+        "UserDefinedHouseholdPowerLimitSourceParameters",
+    ):
+        del data[key]
+
+    config = PeblarUserConfiguration.from_dict(data)
+    assert config.connect_hub_visibility is None
+    assert config.custom_customer_id is None
+    assert config.iso15118_communication_enabled is None
+    assert config.sbo_allowed is None
+    assert config.sbo_enabled is None
+    assert config.session_download_allowed is None
+    assert config.user_defined_household_power_limit_source_parameters == {}
+
+
+def test_household_power_limit_source_parameters_are_decoded() -> None:
+    """Test the household limit parameter blob is unpacked like the others."""
+    config = PeblarUserConfiguration.from_json(
+        patched_fixture(
+            "user_configuration.json",
+            UserDefinedHouseholdPowerLimitSourceParameters='{"address": "meter-1"}',
+        ),
+    )
+    assert config.user_defined_household_power_limit_source_parameters == {
+        "address": "meter-1"
+    }


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Twelve fields the charger reports that we were dropping on the floor. All of them are already present in the repo's own fixtures, captured from a real charger running firmware 1.9.x, so the test data has been documenting the gap for a while.

`PeblarSystemInformation` gains `HwHas4pRelay`, `HwHasDualSocket`, `HwHasShutter`, `HwUKCompliant` and `NorFlash`. `PeblarUserConfiguration` gains `ConnectHubVisibility`, `CustomCustomerId`, `Iso15118CommunicationEnable`, `SboAllowed`, `SboEnabled`, `SessionDownloadAllowed` and `UserDefinedHouseholdPowerLimitSourceParameters`.

Everything is optional, because older firmware leaves them out, and there is a test covering that case for both models. Fields are placed in API alias order like their neighbours, so the models still read against a raw charger payload.

`UserDefinedHouseholdPowerLimitSourceParameters` is another JSON encoded blob, so it joins the existing decoding in `__pre_deserialize__`, which is now a loop over the three keys rather than two open-coded lines.

`SboEnabled` is typed as `str` rather than `bool` on purpose: the charger sends `"Enabled"`, not `true`. Without knowing what its other values are, an enum would be a guess, so it keeps the charger's own shape.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
