### PR TITLE
Expand the settable user configuration

### DIFF
--- a/src/peblar/models.py
+++ b/src/peblar/models.py
@@ -41,6 +41,44 @@ class AwesomeVersionSerializationStrategy(SerializationStrategy, use_annotations
         return version
 
 
+def resolve_smart_charging_mode(
+    mode: SmartChargingMode,
+) -> tuple[bool, bool, SolarChargingMode | None]:
+    """Translate a UI smart charging mode into the charger's own fields.
+
+    The Peblar UI presents a single smart charging mode, while the charger
+    is configured through separate scheduled and solar charging fields.
+    Returns them as a (scheduled, solar, solar mode) tuple.
+    """
+    if mode is SmartChargingMode.SCHEDULED:
+        return True, False, None
+
+    if mode is SmartChargingMode.FAST_SOLAR:
+        return False, True, SolarChargingMode.MAX_SOLAR
+
+    if mode is SmartChargingMode.SMART_SOLAR:
+        return False, True, SolarChargingMode.OPTIMIZED_SOLAR
+
+    if mode is SmartChargingMode.PURE_SOLAR:
+        return False, True, SolarChargingMode.PURE_SOLAR
+
+    return False, False, None
+
+
+def resolve_led_brightness(
+    brightness: LedBrightness,
+) -> tuple[LedIntensityMode, int | None]:
+    """Translate a UI LED brightness level into the charger's own fields.
+
+    Returns an (intensity mode, manual intensity) tuple; the manual
+    intensity is None when the charger follows the ambient light.
+    """
+    if brightness is LedBrightness.AUTOMATIC:
+        return LedIntensityMode.AUTO, None
+
+    return LedIntensityMode.FIXED, brightness.value
+
+
 class BaseModel(DataClassORJSONMixin):
     """Base model for all Peblar models."""
 
@@ -523,9 +561,45 @@ class PeblarUserConfiguration(BaseModel):
 
 
 @dataclass(kw_only=True)
+# pylint: disable-next=too-many-instance-attributes
 class PeblarSetUserConfiguration(BaseModel):
-    """Object to set user configuration of a Peblar charger."""
+    """Object to set user configuration of a Peblar charger.
 
+    Mirrors the writable half of PeblarUserConfiguration. Every field is
+    optional and only the ones that are set end up in the request, so a
+    single call can change one setting or all of them at once.
+    """
+
+    buzzer_volume: SoundVolume | None = field(
+        default=None, metadata=field_options(alias="HmiBuzzerVolume")
+    )
+    led_intensity_manual: int | None = field(
+        default=None, metadata=field_options(alias="HmiLedIntensityManual")
+    )
+    led_intensity_mode: LedIntensityMode | None = field(
+        default=None, metadata=field_options(alias="HmiLedIntensityMode")
+    )
+    local_rest_api_access_mode: AccessMode | None = field(
+        default=None, metadata=field_options(alias="LocalRestApiAccessMode")
+    )
+    local_rest_api_enabled: bool | None = field(
+        default=None, metadata=field_options(alias="LocalRestApiEnable")
+    )
+    modbus_server_access_mode: AccessMode | None = field(
+        default=None, metadata=field_options(alias="ModbusServerAccessMode")
+    )
+    modbus_server_enabled: bool | None = field(
+        default=None, metadata=field_options(alias="ModbusServerEnable")
+    )
+    scheduled_charging_enabled: bool | None = field(
+        default=None, metadata=field_options(alias="ScheduledChargingEnable")
+    )
+    solar_charging_enabled: bool | None = field(
+        default=None, metadata=field_options(alias="SolarChargingEnable")
+    )
+    solar_charging_mode: SolarChargingMode | None = field(
+        default=None, metadata=field_options(alias="SolarChargingMode")
+    )
     user_defined_charge_limit_current: int | None = field(
         default=None, metadata=field_options(alias="UserDefinedChargeLimitCurrent")
     )
@@ -537,6 +611,34 @@ class PeblarSetUserConfiguration(BaseModel):
         default=None,
         metadata=field_options(alias="UserDefinedHouseholdPowerLimitEnable"),
     )
+    user_keep_socket_locked: bool | None = field(
+        default=None, metadata=field_options(alias="UserKeepSocketLocked")
+    )
+
+    # Replicated fields from the Peblar UI
+    led_brightness: LedBrightness | None = field(
+        default=None, metadata=field_options(serialize="omit")
+    )
+    smart_charging: SmartChargingMode | None = field(
+        default=None, metadata=field_options(serialize="omit")
+    )
+
+    def __post_init__(self) -> None:
+        """Post init hook for PeblarSetUserConfiguration object."""
+        if self.smart_charging is not None:
+            (
+                self.scheduled_charging_enabled,
+                self.solar_charging_enabled,
+                solar_charging_mode,
+            ) = resolve_smart_charging_mode(self.smart_charging)
+
+            if solar_charging_mode is not None:
+                self.solar_charging_mode = solar_charging_mode
+
+        if self.led_brightness is not None:
+            self.led_intensity_mode, self.led_intensity_manual = resolve_led_brightness(
+                self.led_brightness
+            )
 
 
 @dataclass(kw_only=True)
@@ -560,25 +662,17 @@ class PeblarSmartCharging(BaseModel):
 
     def __post_init__(self) -> None:
         """Post init hook for PeblarSmartCharging object."""
-        if self.smart_charging:
-            if self.smart_charging == SmartChargingMode.DEFAULT:
-                self.scheduled_charging_enable = False
-                self.solar_charging_enable = False
-            elif self.smart_charging == SmartChargingMode.SCHEDULED:
-                self.scheduled_charging_enable = True
-                self.solar_charging_enable = False
-            elif self.smart_charging == SmartChargingMode.FAST_SOLAR:
-                self.scheduled_charging_enable = False
-                self.solar_charging_enable = True
-                self.solar_charging_mode = SolarChargingMode.MAX_SOLAR
-            elif self.smart_charging == SmartChargingMode.SMART_SOLAR:
-                self.scheduled_charging_enable = False
-                self.solar_charging_enable = True
-                self.solar_charging_mode = SolarChargingMode.OPTIMIZED_SOLAR
-            elif self.smart_charging == SmartChargingMode.PURE_SOLAR:
-                self.scheduled_charging_enable = False
-                self.solar_charging_enable = True
-                self.solar_charging_mode = SolarChargingMode.PURE_SOLAR
+        if self.smart_charging is None:
+            return
+
+        (
+            self.scheduled_charging_enable,
+            self.solar_charging_enable,
+            solar_charging_mode,
+        ) = resolve_smart_charging_mode(self.smart_charging)
+
+        if solar_charging_mode is not None:
+            self.solar_charging_mode = solar_charging_mode
 
 
 @dataclass(kw_only=True)

--- a/src/peblar/models.py
+++ b/src/peblar/models.py
@@ -49,20 +49,29 @@ def resolve_smart_charging_mode(
     The Peblar UI presents a single smart charging mode, while the charger
     is configured through separate scheduled and solar charging fields.
     Returns them as a (scheduled, solar, solar mode) tuple.
+
+    Compares by value, not identity: SmartChargingMode is a StrEnum, so a
+    caller handing over a plain "scheduled" has to mean the same thing as
+    the member itself. Anything unrecognised raises rather than quietly
+    turning both charging modes off.
     """
-    if mode is SmartChargingMode.SCHEDULED:
+    if mode == SmartChargingMode.DEFAULT:
+        return False, False, None
+
+    if mode == SmartChargingMode.SCHEDULED:
         return True, False, None
 
-    if mode is SmartChargingMode.FAST_SOLAR:
+    if mode == SmartChargingMode.FAST_SOLAR:
         return False, True, SolarChargingMode.MAX_SOLAR
 
-    if mode is SmartChargingMode.SMART_SOLAR:
+    if mode == SmartChargingMode.SMART_SOLAR:
         return False, True, SolarChargingMode.OPTIMIZED_SOLAR
 
-    if mode is SmartChargingMode.PURE_SOLAR:
+    if mode == SmartChargingMode.PURE_SOLAR:
         return False, True, SolarChargingMode.PURE_SOLAR
 
-    return False, False, None
+    msg = f"Unknown smart charging mode: {mode!r}"
+    raise ValueError(msg)
 
 
 def resolve_led_brightness(
@@ -72,11 +81,15 @@ def resolve_led_brightness(
 
     Returns an (intensity mode, manual intensity) tuple; the manual
     intensity is None when the charger follows the ambient light.
+
+    Coerces through LedBrightness, so a caller handing over a plain 22
+    means the same thing as the member itself, and an intensity the UI
+    has no name for raises rather than reaching the charger.
     """
-    if brightness is LedBrightness.AUTOMATIC:
+    if LedBrightness(brightness) is LedBrightness.AUTOMATIC:
         return LedIntensityMode.AUTO, None
 
-    return LedIntensityMode.FIXED, brightness.value
+    return LedIntensityMode.FIXED, LedBrightness(brightness).value
 
 
 class BaseModel(DataClassORJSONMixin):

--- a/src/peblar/models.py
+++ b/src/peblar/models.py
@@ -93,6 +93,25 @@ def resolve_led_brightness(
     return LedIntensityMode.FIXED, level.value
 
 
+def reject_conflicting_fields(
+    ui_field: str,
+    driven: dict[str, object],
+) -> None:
+    """Refuse a UI shorthand alongside the fields it expands into.
+
+    The shorthand overwrites those fields, so accepting both would mean
+    silently discarding half of what the caller asked for.
+    """
+    if conflicting := sorted(
+        name for name, value in driven.items() if value is not None
+    ):
+        msg = (
+            f"Set either {ui_field} or {', '.join(conflicting)}, not both: "
+            f"{ui_field} overwrites them"
+        )
+        raise ValueError(msg)
+
+
 class BaseModel(DataClassORJSONMixin):
     """Base model for all Peblar models."""
 
@@ -640,6 +659,14 @@ class PeblarSetUserConfiguration(BaseModel):
     def __post_init__(self) -> None:
         """Post init hook for PeblarSetUserConfiguration object."""
         if self.smart_charging is not None:
+            reject_conflicting_fields(
+                "smart_charging",
+                {
+                    "scheduled_charging_enabled": self.scheduled_charging_enabled,
+                    "solar_charging_enabled": self.solar_charging_enabled,
+                    "solar_charging_mode": self.solar_charging_mode,
+                },
+            )
             (
                 self.scheduled_charging_enabled,
                 self.solar_charging_enabled,
@@ -650,6 +677,13 @@ class PeblarSetUserConfiguration(BaseModel):
                 self.solar_charging_mode = solar_charging_mode
 
         if self.led_brightness is not None:
+            reject_conflicting_fields(
+                "led_brightness",
+                {
+                    "led_intensity_mode": self.led_intensity_mode,
+                    "led_intensity_manual": self.led_intensity_manual,
+                },
+            )
             self.led_intensity_mode, self.led_intensity_manual = resolve_led_brightness(
                 self.led_brightness
             )
@@ -678,6 +712,15 @@ class PeblarSmartCharging(BaseModel):
         """Post init hook for PeblarSmartCharging object."""
         if self.smart_charging is None:
             return
+
+        reject_conflicting_fields(
+            "smart_charging",
+            {
+                "scheduled_charging_enable": self.scheduled_charging_enable,
+                "solar_charging_enable": self.solar_charging_enable,
+                "solar_charging_mode": self.solar_charging_mode,
+            },
+        )
 
         (
             self.scheduled_charging_enable,

--- a/src/peblar/models.py
+++ b/src/peblar/models.py
@@ -86,10 +86,11 @@ def resolve_led_brightness(
     means the same thing as the member itself, and an intensity the UI
     has no name for raises rather than reaching the charger.
     """
-    if LedBrightness(brightness) is LedBrightness.AUTOMATIC:
+    level = LedBrightness(brightness)
+    if level is LedBrightness.AUTOMATIC:
         return LedIntensityMode.AUTO, None
 
-    return LedIntensityMode.FIXED, LedBrightness(brightness).value
+    return LedIntensityMode.FIXED, level.value
 
 
 class BaseModel(DataClassORJSONMixin):

--- a/src/peblar/peblar.py
+++ b/src/peblar/peblar.py
@@ -18,7 +18,6 @@ from tenacity import (
 )
 from yarl import URL
 
-from .const import LedBrightness, LedIntensityMode, SoundVolume
 from .exceptions import (
     PeblarAuthenticationError,
     PeblarBadRequestError,
@@ -50,13 +49,20 @@ from .models import (
     PeblarUpdate,
     PeblarUserConfiguration,
     PeblarVersions,
+    resolve_led_brightness,
 )
 from .utils import build_error_message
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Coroutine
 
-    from peblar.const import AccessMode, PackageType, SmartChargingMode
+    from peblar.const import (
+        AccessMode,
+        LedBrightness,
+        PackageType,
+        SmartChargingMode,
+        SoundVolume,
+    )
 
 
 LOGIN_URI = URL("auth/login")
@@ -297,17 +303,14 @@ class Peblar:
 
     async def set_led_brightness(self, *, brightness: LedBrightness) -> None:
         """Set the LED brightness of the Peblar charger."""
-        if brightness == LedBrightness.AUTOMATIC:
-            data = PeblarLedIntensity(led_intensity_mode=LedIntensityMode.AUTO)
-        else:
-            data = PeblarLedIntensity(
-                led_intensity_mode=LedIntensityMode.FIXED,
-                led_intensity_manual=brightness.value,
-            )
+        led_intensity_mode, led_intensity_manual = resolve_led_brightness(brightness)
         await self.request(
             URL("config/user"),
             method=hdrs.METH_PATCH,
-            data=data,
+            data=PeblarLedIntensity(
+                led_intensity_mode=led_intensity_mode,
+                led_intensity_manual=led_intensity_manual,
+            ),
         )
 
     async def identify(self) -> None:

--- a/tests/test_peblar.py
+++ b/tests/test_peblar.py
@@ -1405,3 +1405,67 @@ def test_smart_charging_payload_from_plain_string() -> None:
             smart_charging=SmartChargingMode.PURE_SOLAR
         ).to_json()
     )
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"scheduled_charging_enabled": True},
+        {"solar_charging_enabled": True},
+        {"solar_charging_mode": SolarChargingMode.PURE_SOLAR},
+    ],
+    ids=["scheduled", "solar", "solar-mode"],
+)
+def test_smart_charging_shorthand_rejects_conflicts(kwargs: dict[str, object]) -> None:
+    """Test the shorthand refuses to silently overwrite what you also set."""
+    with pytest.raises(ValueError, match="not both"):
+        PeblarSetUserConfiguration(
+            smart_charging=SmartChargingMode.SCHEDULED,
+            **kwargs,  # ty: ignore[invalid-argument-type]
+        )
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"led_intensity_mode": LedIntensityMode.AUTO},
+        {"led_intensity_manual": 100},
+    ],
+    ids=["mode", "manual"],
+)
+def test_led_brightness_shorthand_rejects_conflicts(kwargs: dict[str, object]) -> None:
+    """Test the LED shorthand refuses to silently overwrite what you set."""
+    with pytest.raises(ValueError, match="not both"):
+        PeblarSetUserConfiguration(
+            led_brightness=LedBrightness.AUTOMATIC,
+            **kwargs,  # ty: ignore[invalid-argument-type]
+        )
+
+
+def test_smart_charging_model_rejects_conflicts() -> None:
+    """Test the same guard applies to the smart charging payload."""
+    with pytest.raises(ValueError, match="not both"):
+        PeblarSmartCharging(
+            smart_charging=SmartChargingMode.SCHEDULED,
+            solar_charging_enable=True,
+        )
+
+
+def test_shorthand_and_low_level_fields_work_on_their_own() -> None:
+    """Test the guard only fires on a genuine overlap."""
+    assert orjson.loads(
+        PeblarSetUserConfiguration(led_brightness=LedBrightness.MEDIUM).to_json()
+    ) == {"HmiLedIntensityManual": 22, "HmiLedIntensityMode": "Fixed"}
+    assert orjson.loads(
+        PeblarSetUserConfiguration(led_intensity_manual=50).to_json()
+    ) == {"HmiLedIntensityManual": 50}
+    assert orjson.loads(
+        PeblarSetUserConfiguration(
+            smart_charging=SmartChargingMode.SCHEDULED,
+            buzzer_volume=SoundVolume.LOW,
+        ).to_json()
+    ) == {
+        "HmiBuzzerVolume": 1,
+        "ScheduledChargingEnable": True,
+        "SolarChargingEnable": False,
+    }

--- a/tests/test_peblar.py
+++ b/tests/test_peblar.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import cast
+
 import orjson
 import pytest
 from aiohttp import ClientConnectionError, ClientSession
@@ -12,6 +14,7 @@ from peblar.const import (
     AccessMode,
     CPState,
     LedBrightness,
+    LedIntensityMode,
     PackageType,
     SmartChargingMode,
     SolarChargingMode,
@@ -32,6 +35,8 @@ from peblar.models import (
     PeblarSystemInformation,
     PeblarUserConfiguration,
     PeblarVersions,
+    resolve_led_brightness,
+    resolve_smart_charging_mode,
 )
 from peblar.peblar import PeblarApi
 from peblar.utils import build_error_message
@@ -1326,3 +1331,77 @@ def test_set_user_configuration_ui_fields_are_not_sent() -> None:
     )
     assert "smart_charging" not in payload
     assert "led_brightness" not in payload
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected"),
+    [
+        ("default", (False, False, None)),
+        ("scheduled", (True, False, None)),
+        ("fast_solar", (False, True, SolarChargingMode.MAX_SOLAR)),
+        ("smart_solar", (False, True, SolarChargingMode.OPTIMIZED_SOLAR)),
+        ("pure_solar", (False, True, SolarChargingMode.PURE_SOLAR)),
+    ],
+)
+def test_resolve_smart_charging_mode_accepts_plain_strings(
+    mode: str,
+    expected: tuple[bool, bool, SolarChargingMode | None],
+) -> None:
+    """Test a plain string means the same as the enum member.
+
+    SmartChargingMode is a StrEnum, so comparing by identity would send a
+    caller passing "scheduled" down the default path and quietly turn
+    scheduled charging off instead of on.
+    """
+    assert resolve_smart_charging_mode(cast("SmartChargingMode", mode)) == expected
+    assert resolve_smart_charging_mode(SmartChargingMode(mode)) == expected
+
+
+def test_resolve_smart_charging_mode_rejects_unknown() -> None:
+    """Test an unrecognised mode raises instead of disabling everything."""
+    with pytest.raises(ValueError, match="Unknown smart charging mode"):
+        resolve_smart_charging_mode(cast("SmartChargingMode", "nonsense"))
+
+
+@pytest.mark.parametrize(
+    ("brightness", "expected"),
+    [
+        (-1, (LedIntensityMode.AUTO, None)),
+        (0, (LedIntensityMode.FIXED, 0)),
+        (22, (LedIntensityMode.FIXED, 22)),
+        (100, (LedIntensityMode.FIXED, 100)),
+    ],
+)
+def test_resolve_led_brightness_accepts_plain_ints(
+    brightness: int,
+    expected: tuple[LedIntensityMode, int | None],
+) -> None:
+    """Test a plain int means the same as the enum member."""
+    assert resolve_led_brightness(cast("LedBrightness", brightness)) == expected
+    assert resolve_led_brightness(LedBrightness(brightness)) == expected
+
+
+def test_resolve_led_brightness_rejects_unknown() -> None:
+    """Test an intensity the UI has no name for never reaches the charger."""
+    with pytest.raises(ValueError, match="not a valid LedBrightness"):
+        resolve_led_brightness(cast("LedBrightness", 37))
+
+
+def test_smart_charging_payload_from_plain_string() -> None:
+    """Test the payload models accept a plain string just like the enum."""
+    assert orjson.loads(
+        PeblarSmartCharging(
+            smart_charging=cast("SmartChargingMode", "scheduled")
+        ).to_json()
+    ) == orjson.loads(
+        PeblarSmartCharging(smart_charging=SmartChargingMode.SCHEDULED).to_json()
+    )
+    assert orjson.loads(
+        PeblarSetUserConfiguration(
+            smart_charging=cast("SmartChargingMode", "pure_solar")
+        ).to_json()
+    ) == orjson.loads(
+        PeblarSetUserConfiguration(
+            smart_charging=SmartChargingMode.PURE_SOLAR
+        ).to_json()
+    )

--- a/tests/test_peblar.py
+++ b/tests/test_peblar.py
@@ -1207,3 +1207,122 @@ def test_parameter_blob_shapes(blob: object, expected: dict[str, str]) -> None:
     data["BopSourceParameters"] = blob
     config = PeblarUserConfiguration.from_dict(data)
     assert config.bop_source_parameters == expected
+
+
+# ---------------------------------------------------------------------------
+# Expanded user configuration payload
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    ("mode", "expected"),
+    [
+        (
+            SmartChargingMode.DEFAULT,
+            {"ScheduledChargingEnable": False, "SolarChargingEnable": False},
+        ),
+        (
+            SmartChargingMode.SCHEDULED,
+            {"ScheduledChargingEnable": True, "SolarChargingEnable": False},
+        ),
+        (
+            SmartChargingMode.FAST_SOLAR,
+            {
+                "ScheduledChargingEnable": False,
+                "SolarChargingEnable": True,
+                "SolarChargingMode": "MaxSolar",
+            },
+        ),
+        (
+            SmartChargingMode.SMART_SOLAR,
+            {
+                "ScheduledChargingEnable": False,
+                "SolarChargingEnable": True,
+                "SolarChargingMode": "OptimizedSolar",
+            },
+        ),
+        (
+            SmartChargingMode.PURE_SOLAR,
+            {
+                "ScheduledChargingEnable": False,
+                "SolarChargingEnable": True,
+                "SolarChargingMode": "PureSolar",
+            },
+        ),
+    ],
+)
+def test_set_user_configuration_smart_charging(
+    mode: SmartChargingMode,
+    expected: dict[str, object],
+) -> None:
+    """Test the UI smart charging mode expands into the charger's fields."""
+    payload = PeblarSetUserConfiguration(smart_charging=mode)
+    assert orjson.loads(payload.to_json()) == expected
+
+
+@pytest.mark.parametrize(
+    ("brightness", "expected"),
+    [
+        (LedBrightness.AUTOMATIC, {"HmiLedIntensityMode": "Auto"}),
+        (
+            LedBrightness.OFF,
+            {"HmiLedIntensityMode": "Fixed", "HmiLedIntensityManual": 0},
+        ),
+        (
+            LedBrightness.MEDIUM,
+            {"HmiLedIntensityMode": "Fixed", "HmiLedIntensityManual": 22},
+        ),
+        (
+            LedBrightness.BRIGHT,
+            {"HmiLedIntensityMode": "Fixed", "HmiLedIntensityManual": 100},
+        ),
+    ],
+)
+def test_set_user_configuration_led_brightness(
+    brightness: LedBrightness,
+    expected: dict[str, object],
+) -> None:
+    """Test the UI LED brightness expands into the charger's fields."""
+    payload = PeblarSetUserConfiguration(led_brightness=brightness)
+    assert orjson.loads(payload.to_json()) == expected
+
+
+def test_set_user_configuration_omits_untouched_fields() -> None:
+    """Test only the settings you actually set reach the charger."""
+    payload = PeblarSetUserConfiguration(user_defined_charge_limit_current=10)
+    assert orjson.loads(payload.to_json()) == {"UserDefinedChargeLimitCurrent": 10}
+
+
+async def test_update_user_configuration_multiple_settings() -> None:
+    """Test a single update can carry several settings at once."""
+    with aioresponses() as mocked:
+        mocked.patch(USER_CONFIG_URL, status=200, body="", content_type="text/plain")
+        async with Peblar(host=HOST) as peblar:
+            await peblar.update_user_configuration(
+                PeblarSetUserConfiguration(
+                    buzzer_volume=SoundVolume.LOW,
+                    user_defined_charge_limit_current=10,
+                    user_keep_socket_locked=True,
+                    modbus_server_access_mode=AccessMode.READ_ONLY,
+                ),
+            )
+
+    requests = mocked.requests
+    assert requests is not None
+    call = next(iter(requests.values()))[0]
+    assert orjson.loads(call.kwargs["data"]) == {
+        "HmiBuzzerVolume": 1,
+        "ModbusServerAccessMode": "ReadOnly",
+        "UserDefinedChargeLimitCurrent": 10,
+        "UserKeepSocketLocked": True,
+    }
+
+
+def test_set_user_configuration_ui_fields_are_not_sent() -> None:
+    """Test the replicated UI fields never reach the wire themselves."""
+    payload = orjson.loads(
+        PeblarSetUserConfiguration(
+            smart_charging=SmartChargingMode.SCHEDULED,
+            led_brightness=LedBrightness.OFF,
+        ).to_json()
+    )
+    assert "smart_charging" not in payload
+    assert "led_brightness" not in payload


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

`PeblarSetUserConfiguration` only exposed three fields, so anything else meant a dedicated method and a PATCH of its own. It now mirrors the writable half of `PeblarUserConfiguration` with fourteen: buzzer volume, LED intensity, socket lock, charge current limit, household power limit and its enable flag, solar and scheduled charging, and the local REST and Modbus access modes. Everything stays optional and only what you set is sent, so one call can change one setting or all of them.

It also carries the two replicated UI fields, `smart_charging` and `led_brightness`, which expand into the charger's own representation and are never serialised themselves.

That expansion logic already existed in two places: an if/elif ladder in `PeblarSmartCharging.__post_init__`, and the same idea inline in `Peblar.set_led_brightness`. Both now go through shared `resolve_smart_charging_mode()` and `resolve_led_brightness()` helpers, so the UI to charger translation lives in exactly one place. The existing smart charging tests pass unchanged, which is what makes that a refactor rather than a rewrite.

One side effect worth noting: moving the runtime enum comparison into the helpers left `LedBrightness` and `SoundVolume` used only in annotations in `peblar.py`, so ruff wants them under `TYPE_CHECKING`.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
