### PR TITLE
Complete the local REST API coverage

### DIFF
--- a/src/peblar/__init__.py
+++ b/src/peblar/__init__.py
@@ -1,7 +1,9 @@
 """Asynchronous Python client for Peblar EV chargers."""
 
 from .const import (
+    MINIMUM_FIRMWARE_VERSION_LOCAL_REST_API,
     AccessMode,
+    AuthorizationMethod,
     ChargeLimiter,
     CPState,
     LedBrightness,
@@ -17,6 +19,7 @@ from .exceptions import (
     PeblarConnectionTimeoutError,
     PeblarError,
     PeblarResponseError,
+    PeblarUnsupportedFirmwareVersionError,
 )
 from .models import (
     PeblarEVInterface,
@@ -32,7 +35,9 @@ from .models import (
 from .peblar import Peblar, PeblarApi
 
 __all__ = [
+    "MINIMUM_FIRMWARE_VERSION_LOCAL_REST_API",
     "AccessMode",
+    "AuthorizationMethod",
     "CPState",
     "ChargeLimiter",
     "LedBrightness",
@@ -52,6 +57,7 @@ __all__ = [
     "PeblarSetUserConfiguration",
     "PeblarSystem",
     "PeblarSystemInformation",
+    "PeblarUnsupportedFirmwareVersionError",
     "PeblarUserConfiguration",
     "PeblarVersions",
     "SmartChargingMode",

--- a/src/peblar/cli/__init__.py
+++ b/src/peblar/cli/__init__.py
@@ -559,13 +559,17 @@ def rate_limit_error_handler(_: PeblarRateLimitError) -> None:
 
 @cli.error_handler(PeblarUnsupportedFirmwareVersionError)
 def unsupported_firmware_version_error_handler(
-    _: PeblarUnsupportedFirmwareVersionError,
+    error: PeblarUnsupportedFirmwareVersionError,
 ) -> None:
     """Handle unsupported version errors."""
-    message = """
+    message = f"""
     The specified Peblar charger is running an unsupported firmware version.
 
-    The tooling currently only supports firmware versions XXX and higher.
+    {error}
+
+    Update the charger and try again:
+
+    peblar update
     """
     panel = Panel(
         message,
@@ -1863,6 +1867,66 @@ async def ev(
     )
 
     console.print(table)
+
+
+@cli.command("authorize")
+async def authorize(
+    host: Annotated[
+        str,
+        typer.Option(
+            help="Peblar charger IP address or hostname",
+            prompt="Host address",
+            show_default=False,
+            envvar="PEBLAR_HOST",
+        ),
+    ],
+    password: Annotated[
+        str,
+        typer.Option(
+            help="Peblar charger login password",
+            prompt="Password",
+            show_default=False,
+            hide_input=True,
+            envvar="PEBLAR_PASSWORD",
+        ),
+    ],
+    uid: Annotated[
+        str | None,
+        typer.Option(
+            help="RFID token UID from the standalone auth list",
+            show_default=False,
+        ),
+    ] = None,
+    name: Annotated[
+        str | None,
+        typer.Option(
+            help="RFID token description from the standalone auth list",
+            show_default=False,
+        ),
+    ] = None,
+    quiet: Annotated[bool, QUIET_OPTION] = False,
+) -> None:
+    """Authorize or deauthorize the running charge session.
+
+    Presents a token from the standalone auth list as if it were held
+    against the reader. The charger toggles: it authorizes an unauthorized
+    session and stops an authorized one.
+    """
+    if (uid is None) == (name is None):
+        msg = "Provide either --uid or --name, but not both."
+        raise typer.BadParameter(msg)
+
+    status_ctx = (
+        contextlib.nullcontext()
+        if quiet
+        else console.status("[cyan]Presenting token...", spinner="toggle12")
+    )
+    with status_ctx:
+        async with Peblar(host=host) as peblar:
+            await peblar.login(password=password)
+            async with await peblar.rest_api() as api:
+                await api.authorize_charge_session(token=uid, name=name)
+    print_cli_success(quiet=quiet, message="✅[green]Success!")
 
 
 @cli.command("health")

--- a/src/peblar/cli/__init__.py
+++ b/src/peblar/cli/__init__.py
@@ -1913,7 +1913,7 @@ async def authorize(
     session and stops an authorized one.
     """
     if (uid is None) == (name is None):
-        msg = "Provide either --uid or --name, but not both."
+        msg = "Provide exactly one of --uid or --name."
         raise typer.BadParameter(msg)
 
     status_ctx = (

--- a/src/peblar/const.py
+++ b/src/peblar/const.py
@@ -2,8 +2,8 @@
 
 from enum import IntEnum, StrEnum
 
+# Firmware version that introduced the local REST API.
 MINIMUM_FIRMWARE_VERSION_LOCAL_REST_API = "1.6"
-"""Firmware version that introduced the local REST API."""
 
 
 class AccessMode(StrEnum):

--- a/src/peblar/const.py
+++ b/src/peblar/const.py
@@ -2,6 +2,9 @@
 
 from enum import IntEnum, StrEnum
 
+MINIMUM_FIRMWARE_VERSION_LOCAL_REST_API = "1.6"
+"""Firmware version that introduced the local REST API."""
+
 
 class AccessMode(StrEnum):
     """Peblar access mode."""
@@ -11,6 +14,13 @@ class AccessMode(StrEnum):
 
     READ_ONLY = "ReadOnly"
     """Read only access."""
+
+
+class AuthorizationMethod(StrEnum):
+    """Peblar charge session authorization method."""
+
+    RFID = "Rfid"
+    """Authorize using an RFID token from the standalone auth list."""
 
 
 class SolarChargingMode(StrEnum):
@@ -146,6 +156,9 @@ class ChargeLimiter(StrEnum):
 
     POWER_FACTOR = "Power factor"
     """Charging limited by the maximum current due to power factor."""
+
+    RESERVED = "Reserved"
+    """Charging limited by a source reserved for internal development."""
 
     SOLAR_CHARGING = "Solar charging"
     """Charging limited by the maximum current due to solar charging."""

--- a/src/peblar/models.py
+++ b/src/peblar/models.py
@@ -14,6 +14,7 @@ from mashumaro.types import SerializationStrategy
 
 from .const import (
     AccessMode,
+    AuthorizationMethod,
     ChargeLimiter,
     CPState,
     LedBrightness,
@@ -219,6 +220,28 @@ class PeblarRfidToken(BaseModel):
     rfid_token_description: str = field(
         metadata=field_options(alias="RfidTokenDescription")
     )
+
+
+@dataclass(kw_only=True)
+class PeblarChargeSessionAuthorization(BaseModel):
+    """Object holding the charge session (de)authorization payload.
+
+    The charger looks the token up in the standalone auth list, either by
+    its UID or by the description it was stored under. Exactly one of the
+    two is required.
+    """
+
+    method: AuthorizationMethod = field(
+        default=AuthorizationMethod.RFID, metadata=field_options(alias="Method")
+    )
+    token: str | None = field(default=None, metadata=field_options(alias="Token"))
+    name: str | None = field(default=None, metadata=field_options(alias="Name"))
+
+    def __post_init__(self) -> None:
+        """Post init hook for PeblarChargeSessionAuthorization object."""
+        if (self.token is None) == (self.name is None):
+            msg = "Provide either a token UID or a token name, but not both"
+            raise ValueError(msg)
 
 
 @dataclass(kw_only=True)
@@ -849,6 +872,20 @@ class PeblarEVInterfaceChange(BaseModel):
     force_single_phase: bool | None = field(
         default=None, metadata=field_options(alias="Force1Phase")
     )
+
+
+@dataclass(kw_only=True)
+class PeblarEVInterfaceReplace(BaseModel):
+    """Object holding the complete EV interface configuration payload.
+
+    Unlike a change payload, the charger rejects a replacement that leaves
+    any writable field out, so both fields are required here.
+    """
+
+    charge_current_limit: int = field(
+        metadata=field_options(alias="ChargeCurrentLimit")
+    )
+    force_single_phase: bool = field(metadata=field_options(alias="Force1Phase"))
 
 
 @dataclass(kw_only=True)

--- a/src/peblar/models.py
+++ b/src/peblar/models.py
@@ -240,7 +240,7 @@ class PeblarChargeSessionAuthorization(BaseModel):
     def __post_init__(self) -> None:
         """Post init hook for PeblarChargeSessionAuthorization object."""
         if (self.token is None) == (self.name is None):
-            msg = "Provide either a token UID or a token name, but not both"
+            msg = "Provide exactly one of a token UID or a token name"
             raise ValueError(msg)
 
 

--- a/src/peblar/peblar.py
+++ b/src/peblar/peblar.py
@@ -18,6 +18,10 @@ from tenacity import (
 )
 from yarl import URL
 
+from .const import (
+    MINIMUM_FIRMWARE_VERSION_LOCAL_REST_API,
+    AuthorizationMethod,
+)
 from .exceptions import (
     PeblarAuthenticationError,
     PeblarBadRequestError,
@@ -25,13 +29,16 @@ from .exceptions import (
     PeblarConnectionTimeoutError,
     PeblarError,
     PeblarRateLimitError,
+    PeblarUnsupportedFirmwareVersionError,
 )
 from .models import (
     BaseModel,
     PeblarApiToken,
     PeblarBuzzerVolume,
+    PeblarChargeSessionAuthorization,
     PeblarEVInterface,
     PeblarEVInterfaceChange,
+    PeblarEVInterfaceReplace,
     PeblarHealth,
     PeblarLedIntensity,
     PeblarLocalRestApiAccess,
@@ -51,7 +58,7 @@ from .models import (
     PeblarVersions,
     resolve_led_brightness,
 )
-from .utils import build_error_message
+from .utils import build_error_message, get_awesome_version
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Coroutine
@@ -198,6 +205,17 @@ class Peblar:
         access_mode: AccessMode | None = None,
     ) -> PeblarApi:
         """Get and control access to the REST API."""
+        # Older firmware simply has no local REST API to hand out, and its
+        # user configuration does not carry the fields checked below.
+        versions = await self.current_versions()
+        minimum = get_awesome_version(MINIMUM_FIRMWARE_VERSION_LOCAL_REST_API)
+        if versions.firmware_version and versions.firmware_version < minimum:
+            msg = (
+                f"The local REST API requires firmware {minimum} or later, "
+                f"this charger runs {versions.firmware_version}."
+            )
+            raise PeblarUnsupportedFirmwareVersionError(msg)
+
         user = await self.user_configuration()
         if not user.local_rest_api_allowed:
             msg = "The use of the local REST API is not allowed for this device."
@@ -570,6 +588,56 @@ class PeblarApi:
 
         result = await self.request(url)
         return PeblarEVInterface.from_json(result)
+
+    async def set_ev_interface(
+        self,
+        *,
+        charge_current_limit: int,
+        force_single_phase: bool,
+    ) -> PeblarEVInterface:
+        """Replace the complete EV interface configuration.
+
+        Where ev_interface() patches individual fields, this writes them
+        all in one go. The charger answers with the resulting state, so no
+        follow-up read is needed.
+        """
+        result = await self.request(
+            URL("evinterface"),
+            method=hdrs.METH_PUT,
+            data=PeblarEVInterfaceReplace(
+                charge_current_limit=charge_current_limit,
+                force_single_phase=force_single_phase,
+            ),
+        )
+        return PeblarEVInterface.from_json(result)
+
+    async def authorize_charge_session(
+        self,
+        *,
+        token: str | None = None,
+        name: str | None = None,
+        method: AuthorizationMethod = AuthorizationMethod.RFID,
+    ) -> None:
+        """Authorize or deauthorize the running charge session.
+
+        Presents a token from the standalone auth list to the charger, as
+        if it were held against the reader. Identify it by its UID
+        (`token`) or by its description (`name`), not both. The charger
+        toggles: it authorizes an unauthorized session and stops an
+        authorized one.
+
+        The charger accepts the request before acting on it, so watch the
+        EV interface state to see the result land.
+        """
+        await self.request(
+            URL("authorization/charge-session"),
+            method=hdrs.METH_POST,
+            data=PeblarChargeSessionAuthorization(
+                method=method,
+                token=token,
+                name=name,
+            ),
+        )
 
     async def health(self) -> PeblarHealth:
         """Get health information from the Peblar API."""

--- a/tests/cli/__snapshots__/test_cli.ambr
+++ b/tests/cli/__snapshots__/test_cli.ambr
@@ -28,6 +28,13 @@
       'read',
       'write',
     ]),
+    'authorize': list([
+      'host',
+      'name',
+      'password',
+      'quiet',
+      'uid',
+    ]),
     'buzzer': list([
       'host',
       'password',
@@ -380,7 +387,11 @@
   │                                                                              │
   │     The specified Peblar charger is running an unsupported firmware version. │
   │                                                                              │
-  │     The tooling currently only supports firmware versions XXX and higher.    │
+  │     too old                                                                  │
+  │                                                                              │
+  │     Update the charger and try again:                                        │
+  │                                                                              │
+  │     peblar update                                                            │
   │                                                                              │
   ╰──────────────────────────────────────────────────────────────────────────────╯
   

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -488,7 +488,7 @@ def test_authorize_requires_exactly_one_identifier(
     mock_cls = _mock_peblar_with_api({"authorize_charge_session": None}, login=None)
     exit_code, output = _invoke(runner, ["authorize", *_AUTH, *args], mock_cls)
     assert exit_code != 0
-    assert "not both" in output
+    assert "exactly one" in output
 
 
 def test_unsupported_firmware_handler_shows_the_versions(

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -450,3 +450,60 @@ def test_config_on_older_firmware_shows_no_literal_none(
     # The parameter blob defaults to an empty dict, not None, so it renders
     # blank instead of "N/A"; every other absent setting shows "N/A".
     assert output.count("N/A") == len(NEWER_USER_CONFIGURATION_KEYS) - 1
+
+
+def test_authorize_by_uid(runner: CliRunner) -> None:
+    """Authorize command presents a token by its UID."""
+    mock_cls = _mock_peblar_with_api({"authorize_charge_session": None}, login=None)
+    exit_code, output = _invoke(
+        runner, ["authorize", *_AUTH, "--uid", "0123456789ABCD"], mock_cls
+    )
+    assert exit_code == 0
+    assert "Success" in output
+
+
+def test_authorize_by_name(runner: CliRunner) -> None:
+    """Authorize command presents a token by its description."""
+    mock_cls = _mock_peblar_with_api({"authorize_charge_session": None}, login=None)
+    exit_code, output = _invoke(
+        runner, ["authorize", *_AUTH, "--name", "My RFID Card"], mock_cls
+    )
+    assert exit_code == 0
+    assert "Success" in output
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        [],
+        ["--uid", "0123456789ABCD", "--name", "My RFID Card"],
+    ],
+    ids=["neither", "both"],
+)
+def test_authorize_requires_exactly_one_identifier(
+    runner: CliRunner,
+    args: list[str],
+) -> None:
+    """Authorize command rejects zero or two token identifiers."""
+    mock_cls = _mock_peblar_with_api({"authorize_charge_session": None}, login=None)
+    exit_code, output = _invoke(runner, ["authorize", *_AUTH, *args], mock_cls)
+    assert exit_code != 0
+    assert "not both" in output
+
+
+def test_unsupported_firmware_handler_shows_the_versions(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The firmware panel shows what the charger runs, not a placeholder."""
+    handler = cli.error_handlers[PeblarUnsupportedFirmwareVersionError]
+    with pytest.raises(SystemExit):
+        handler(
+            PeblarUnsupportedFirmwareVersionError(
+                "The local REST API requires firmware 1.6 or later, "
+                "this charger runs 1.5.0."
+            )
+        )
+    output = capsys.readouterr().out
+    assert "1.6" in output
+    assert "1.5.0" in output
+    assert "XXX" not in output

--- a/tests/test_peblar.py
+++ b/tests/test_peblar.py
@@ -1586,7 +1586,7 @@ async def test_api_authorize_charge_session_needs_exactly_one(
 ) -> None:
     """Test the charge session payload insists on exactly one identifier."""
     async with PeblarApi(host=HOST, token="t") as api:
-        with pytest.raises(ValueError, match="not both"):
+        with pytest.raises(ValueError, match="exactly one"):
             await api.authorize_charge_session(token=token, name=name)
 
 

--- a/tests/test_peblar.py
+++ b/tests/test_peblar.py
@@ -12,6 +12,7 @@ from aioresponses import aioresponses
 from peblar import Peblar
 from peblar.const import (
     AccessMode,
+    ChargeLimiter,
     CPState,
     LedBrightness,
     LedIntensityMode,
@@ -27,8 +28,10 @@ from peblar.exceptions import (
     PeblarConnectionTimeoutError,
     PeblarError,
     PeblarRateLimitError,
+    PeblarUnsupportedFirmwareVersionError,
 )
 from peblar.models import (
+    PeblarEVInterface,
     PeblarMeter,
     PeblarSetUserConfiguration,
     PeblarSmartCharging,
@@ -75,6 +78,21 @@ def patched_fixture(filename: str, **overrides: object) -> str:
     data = orjson.loads(load_fixture(filename))
     data.update(overrides)
     return orjson.dumps(data).decode()
+
+
+def request_payload(mocked: aioresponses) -> dict[str, object]:
+    """Return the decoded JSON body of the single request that was made."""
+    requests = mocked.requests
+    assert requests is not None
+    call = next(iter(requests.values()))[0]
+    return orjson.loads(call.kwargs["data"])
+
+
+def mock_firmware_check(mocked: aioresponses) -> None:
+    """Mock the firmware version lookup that rest_api() does up front."""
+    mocked.get(
+        CURRENT_VERSIONS_URL, status=200, body=load_fixture("versions_current.json")
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -364,6 +382,7 @@ async def test_rest_api_disallowed() -> None:
     """Test rest_api raises when the charger disallows the local REST API."""
     body = patched_fixture("user_configuration.json", LocalRestApiAllowed=False)
     with aioresponses() as mocked:
+        mock_firmware_check(mocked)
         mocked.get(USER_CONFIG_URL, status=200, body=body)
         async with Peblar(host=HOST) as peblar:
             with pytest.raises(PeblarError, match="not allowed"):
@@ -374,6 +393,7 @@ async def test_rest_api_disabled() -> None:
     """Test rest_api raises when the local REST API is disabled."""
     body = patched_fixture("user_configuration.json", LocalRestApiEnable=False)
     with aioresponses() as mocked:
+        mock_firmware_check(mocked)
         mocked.get(USER_CONFIG_URL, status=200, body=body)
         async with Peblar(host=HOST) as peblar:
             with pytest.raises(PeblarError, match="not enabled"):
@@ -384,6 +404,7 @@ async def test_rest_api_enable_flow() -> None:
     """Test rest_api toggles the API on via PATCH when currently disabled."""
     body = patched_fixture("user_configuration.json", LocalRestApiEnable=False)
     with aioresponses() as mocked:
+        mock_firmware_check(mocked)
         mocked.get(USER_CONFIG_URL, status=200, body=body)
         mocked.patch(USER_CONFIG_URL, status=200, body="", content_type="text/plain")
         mocked.get(API_TOKEN_URL, status=200, body=load_fixture("api_token.json"))
@@ -559,6 +580,7 @@ async def test_api_401_without_refresh_callback() -> None:
 async def test_peblar_login_stores_password_for_refresh() -> None:
     """Test that login() stores the password so rest_api() can refresh tokens."""
     with aioresponses() as mocked:
+        mock_firmware_check(mocked)
         mocked.post(LOGIN_URL, status=200, body="", content_type="text/plain")
         mocked.get(
             USER_CONFIG_URL, status=200, body=load_fixture("user_configuration.json")
@@ -606,6 +628,7 @@ async def test_rest_api_already_enabled_noop() -> None:
     """Test rest_api skips the PATCH when enable already matches current state."""
     body = load_fixture("user_configuration.json")
     with aioresponses() as mocked:
+        mock_firmware_check(mocked)
         mocked.get(USER_CONFIG_URL, status=200, body=body)
         # No PATCH mock: if rest_api tries to PATCH, aioresponses raises ConnectionError
         mocked.get(API_TOKEN_URL, status=200, body=load_fixture("api_token.json"))
@@ -618,6 +641,7 @@ async def test_rest_api_access_mode_already_matches() -> None:
     """Test rest_api skips the PATCH when access_mode matches current state."""
     body = load_fixture("user_configuration.json")
     with aioresponses() as mocked:
+        mock_firmware_check(mocked)
         mocked.get(USER_CONFIG_URL, status=200, body=body)
         mocked.get(API_TOKEN_URL, status=200, body=load_fixture("api_token.json"))
         async with Peblar(host=HOST) as peblar:
@@ -1469,3 +1493,106 @@ def test_shorthand_and_low_level_fields_work_on_their_own() -> None:
         "ScheduledChargingEnable": True,
         "SolarChargingEnable": False,
     }
+
+
+# ---------------------------------------------------------------------------
+# Local REST API: firmware guard, PUT and charge session authorization
+# ---------------------------------------------------------------------------
+API_AUTHORIZATION_URL = API_BASE_URL + "authorization/charge-session"
+
+
+async def test_rest_api_unsupported_firmware() -> None:
+    """Test rest_api refuses firmware older than the local REST API itself."""
+    body = patched_fixture("versions_current.json", Firmware="1.5.0+1+WL-1")
+    with aioresponses() as mocked:
+        mocked.get(CURRENT_VERSIONS_URL, status=200, body=body)
+        async with Peblar(host=HOST) as peblar:
+            with pytest.raises(
+                PeblarUnsupportedFirmwareVersionError, match="requires firmware"
+            ):
+                await peblar.rest_api()
+
+
+async def test_rest_api_unparsable_firmware_is_allowed() -> None:
+    """Test an unreadable firmware version does not block the local REST API."""
+    body = patched_fixture("versions_current.json", Firmware="")
+    with aioresponses() as mocked:
+        mocked.get(CURRENT_VERSIONS_URL, status=200, body=body)
+        mocked.get(
+            USER_CONFIG_URL, status=200, body=load_fixture("user_configuration.json")
+        )
+        mocked.get(API_TOKEN_URL, status=200, body=load_fixture("api_token.json"))
+        async with Peblar(host=HOST) as peblar:
+            api = await peblar.rest_api()
+            await api.close()
+    assert api.token == "0" * 64
+
+
+async def test_api_set_ev_interface() -> None:
+    """Test set_ev_interface PUTs and parses the returned state."""
+    with aioresponses() as mocked:
+        mocked.put(API_EV_URL, status=200, body=load_fixture("ev_interface.json"))
+        async with PeblarApi(host=HOST, token="t") as api:
+            ev_interface = await api.set_ev_interface(
+                charge_current_limit=16000,
+                force_single_phase=False,
+            )
+    assert ev_interface.charge_current_limit == 16000
+    assert request_payload(mocked) == {
+        "ChargeCurrentLimit": 16000,
+        "Force1Phase": False,
+    }
+
+
+async def test_api_authorize_charge_session_by_token() -> None:
+    """Test authorizing a charge session with a token UID."""
+    with aioresponses() as mocked:
+        mocked.post(
+            API_AUTHORIZATION_URL, status=202, body="", content_type="text/plain"
+        )
+        async with PeblarApi(host=HOST, token="t") as api:
+            await api.authorize_charge_session(token="0123456789ABCD")
+    assert request_payload(mocked) == {
+        "Method": "Rfid",
+        "Token": "0123456789ABCD",
+    }
+
+
+async def test_api_authorize_charge_session_by_name() -> None:
+    """Test authorizing a charge session with a token description."""
+    with aioresponses() as mocked:
+        mocked.post(
+            API_AUTHORIZATION_URL, status=202, body="", content_type="text/plain"
+        )
+        async with PeblarApi(host=HOST, token="t") as api:
+            await api.authorize_charge_session(name="My RFID Card")
+    assert request_payload(mocked) == {
+        "Method": "Rfid",
+        "Name": "My RFID Card",
+    }
+
+
+@pytest.mark.parametrize(
+    ("token", "name"),
+    [
+        (None, None),
+        ("0123456789ABCD", "My RFID Card"),
+    ],
+    ids=["neither", "both"],
+)
+async def test_api_authorize_charge_session_needs_exactly_one(
+    token: str | None,
+    name: str | None,
+) -> None:
+    """Test the charge session payload insists on exactly one identifier."""
+    async with PeblarApi(host=HOST, token="t") as api:
+        with pytest.raises(ValueError, match="not both"):
+            await api.authorize_charge_session(token=token, name=name)
+
+
+def test_charge_limiter_reserved() -> None:
+    """Test the reserved limiter source Peblar documents is recognised."""
+    ev_interface = PeblarEVInterface.from_json(
+        patched_fixture("ev_interface.json", ChargeCurrentLimitSource="Reserved"),
+    )
+    assert ev_interface.charge_current_limit_source is ChargeLimiter.RESERVED


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Closes the remaining gaps against Peblar's published OpenAPI spec for the local REST API.

`POST /authorization/charge-session` was the one documented endpoint with no implementation at all. It presents a token from the standalone auth list as if it were held against the reader, identified either by UID or by the description it was stored under, and toggles the session. That is a different mechanism from driving the charge current limit to zero.

`PUT /evinterface` writes every writable field at once and answers with the resulting state, so unlike the PATCH path it needs no follow-up read.

`ChargeLimiter` was missing `Reserved`, which the spec documents. A charger reporting it would have failed to deserialize the whole EV interface response.

The spec also states the local REST API arrived in firmware 1.6. `rest_api()` now checks the version first and raises `PeblarUnsupportedFirmwareVersionError`, an exception that existed and was handled by the CLI but was never raised by anything. Checking before reading the user configuration matters, because older firmware does not carry the fields that check relies on. Its CLI panel used to say "supports firmware versions XXX and higher" and now prints the real numbers.

Two things worth flagging. `rest_api()` now costs one extra request for the version preflight; it is a setup time call, so that seemed a fair trade for failing clearly instead of on a later 404. And `PeblarChargeSessionAuthorization` raises when given both a UID and a name, or neither, since the spec models those as `oneOf` and there is no sensible default.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
