### PR TITLE
Add the device state endpoints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,7 +101,7 @@ good-names = ["_", "ex", "fp", "i", "id", "j", "k", "on", "Run", "T"]
 
 [tool.pylint.DESIGN]
 max-attributes = 8
-max-public-methods = 25
+max-public-methods = 40
 
 [tool.pylint."MESSAGES CONTROL"]
 disable = ["duplicate-code", "format", "unsubscriptable-object"]

--- a/src/peblar/__init__.py
+++ b/src/peblar/__init__.py
@@ -22,6 +22,8 @@ from .exceptions import (
     PeblarUnsupportedFirmwareVersionError,
 )
 from .models import (
+    PeblarAuthStatus,
+    PeblarConnector,
     PeblarEVInterface,
     PeblarHealth,
     PeblarMeter,
@@ -44,10 +46,12 @@ __all__ = [
     "LedIntensityMode",
     "Peblar",
     "PeblarApi",
+    "PeblarAuthStatus",
     "PeblarAuthenticationError",
     "PeblarBadRequestError",
     "PeblarConnectionError",
     "PeblarConnectionTimeoutError",
+    "PeblarConnector",
     "PeblarEVInterface",
     "PeblarError",
     "PeblarHealth",

--- a/src/peblar/cli/__init__.py
+++ b/src/peblar/cli/__init__.py
@@ -2171,6 +2171,50 @@ async def system(
     console.print(table)
 
 
+@cli.command("status")
+async def status(
+    host: Annotated[
+        str,
+        typer.Option(
+            help="Peblar charger IP address or hostname",
+            prompt="Host address",
+            show_default=False,
+            envvar="PEBLAR_HOST",
+        ),
+    ],
+    password: Annotated[
+        str,
+        typer.Option(
+            help="Peblar charger login password",
+            prompt="Password",
+            show_default=False,
+            hide_input=True,
+            envvar="PEBLAR_PASSWORD",
+        ),
+    ],
+    quiet: Annotated[bool, QUIET_OPTION] = False,  # noqa: ARG001  # pylint: disable=unused-argument
+) -> None:
+    """Show the live status of the Peblar charger."""
+    async with Peblar(host=host) as peblar:
+        await peblar.login(password=password)
+        connector = await peblar.connector()
+        time_synced = await peblar.time_synced()
+        mode = await peblar.web_interface_mode()
+
+    table = Table(title="Peblar charger status")
+    table.add_column("Property", style="cyan bold")
+    table.add_column("Value", style="bold")
+
+    table.add_row(
+        "Cable plugged into charger", convert_to_string(connector.plugged_in_evse)
+    )
+    table.add_row("Cable plugged into EV", convert_to_string(connector.plugged_in_ev))
+    table.add_row("Time synchronized", convert_to_string(time_synced))
+    table.add_row("Web interface mode", mode)
+
+    console.print(table)
+
+
 @cli.command("scan")
 async def scan(
     quiet: Annotated[bool, QUIET_OPTION] = False,

--- a/src/peblar/models.py
+++ b/src/peblar/models.py
@@ -128,6 +128,40 @@ class BaseModel(DataClassORJSONMixin):
 
 
 @dataclass(kw_only=True)
+class PeblarAuthStatus(BaseModel):
+    """Object holding the state of the current web interface session."""
+
+    active: bool = field(metadata=field_options(alias="Active"))
+    version_hash: int = field(metadata=field_options(alias="VersionHash"))
+    """Changes when the charger's software changes, invalidating the session."""
+
+
+@dataclass(kw_only=True)
+class PeblarConnector(BaseModel):
+    """Object holding what is physically plugged into the charger."""
+
+    plugged_in_ev: bool = field(metadata=field_options(alias="PluggedInEV"))
+    """A cable is plugged into the vehicle."""
+
+    plugged_in_evse: bool = field(metadata=field_options(alias="PluggedInEVSE"))
+    """A cable is plugged into the charger."""
+
+
+@dataclass(kw_only=True)
+class PeblarNtpSync(BaseModel):
+    """Object holding the time synchronization state of the charger."""
+
+    time_synced: bool = field(metadata=field_options(alias="TimeSynced"))
+
+
+@dataclass(kw_only=True)
+class PeblarWebInterfaceMode(BaseModel):
+    """Object holding the mode the charger's web interface is running in."""
+
+    mode: str = field(metadata=field_options(alias="Mode"))
+
+
+@dataclass(kw_only=True)
 class PeblarApiToken(BaseModel):
     """Object holding the API token for the Peblar charger."""
 

--- a/src/peblar/peblar.py
+++ b/src/peblar/peblar.py
@@ -34,8 +34,10 @@ from .exceptions import (
 from .models import (
     BaseModel,
     PeblarApiToken,
+    PeblarAuthStatus,
     PeblarBuzzerVolume,
     PeblarChargeSessionAuthorization,
+    PeblarConnector,
     PeblarEVInterface,
     PeblarEVInterfaceChange,
     PeblarEVInterfaceReplace,
@@ -46,6 +48,7 @@ from .models import (
     PeblarMeter,
     PeblarMeterHistory,
     PeblarModbusApiAccess,
+    PeblarNtpSync,
     PeblarReboot,
     PeblarRfidToken,
     PeblarSetUserConfiguration,
@@ -56,6 +59,7 @@ from .models import (
     PeblarUpdate,
     PeblarUserConfiguration,
     PeblarVersions,
+    PeblarWebInterfaceMode,
     resolve_led_brightness,
 )
 from .utils import build_error_message, get_awesome_version
@@ -414,6 +418,35 @@ class Peblar:
         """Get information about the Peblar charger."""
         result = await self.request(URL("system/info"))
         return PeblarSystemInformation.from_json(result)
+
+    async def logout(self) -> None:
+        """Log out of the Peblar charger, ending the current session.
+
+        Also forgets the stored password, so a later request will not
+        quietly log back in again.
+        """
+        await self.request(URL("auth/logout"), method=hdrs.METH_POST)
+        self._password = None
+
+    async def auth_status(self) -> PeblarAuthStatus:
+        """Get the state of the current web interface session."""
+        result = await self.request(URL("auth/status"))
+        return PeblarAuthStatus.from_json(result)
+
+    async def connector(self) -> PeblarConnector:
+        """Get what is currently plugged into the charger."""
+        result = await self.request(URL("system/connector"))
+        return PeblarConnector.from_json(result)
+
+    async def time_synced(self) -> bool:
+        """Return whether the charger's clock is synchronized."""
+        result = await self.request(URL("system/ntp-sync"))
+        return PeblarNtpSync.from_json(result).time_synced
+
+    async def web_interface_mode(self) -> str:
+        """Return the mode the charger's web interface is running in."""
+        result = await self.request(URL("system/web-interface-mode"))
+        return PeblarWebInterfaceMode.from_json(result).mode
 
     async def user_configuration(self) -> PeblarUserConfiguration:
         """Get information about the user configuration."""

--- a/tests/cli/__snapshots__/test_cli.ambr
+++ b/tests/cli/__snapshots__/test_cli.ambr
@@ -147,6 +147,11 @@
       'scheduled',
       'smart_solar',
     ]),
+    'status': list([
+      'host',
+      'password',
+      'quiet',
+    ]),
     'system': list([
       'host',
       'password',
@@ -355,6 +360,20 @@
   │     Give it a moment and try again.                                         │
   │                                                                             │
   ╰─────────────────────────────────────────────────────────────────────────────╯
+  
+  '''
+# ---
+# name: test_status
+  '''
+            Peblar charger status           
+  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┓
+  ┃ Property                   ┃ Value     ┃
+  ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━┩
+  │ Cable plugged into charger │ ✅        │
+  │ Cable plugged into EV      │ ❌        │
+  │ Time synchronized          │ ✅        │
+  │ Web interface mode         │ dashboard │
+  └────────────────────────────┴───────────┘
   
   '''
 # ---

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -20,6 +20,7 @@ from peblar.exceptions import (
     PeblarUnsupportedFirmwareVersionError,
 )
 from peblar.models import (
+    PeblarConnector,
     PeblarHealth,
     PeblarMeter,
     PeblarSystem,
@@ -507,3 +508,17 @@ def test_unsupported_firmware_handler_shows_the_versions(
     assert "1.6" in output
     assert "1.5.0" in output
     assert "XXX" not in output
+
+
+def test_status(runner: CliRunner, snapshot: SnapshotAssertion) -> None:
+    """Status command renders the charger's live state."""
+    connector = PeblarConnector.from_json(load_fixture("connector.json"))
+    mock_cls = _mock_peblar(
+        login=None,
+        connector=connector,
+        time_synced=True,
+        web_interface_mode="dashboard",
+    )
+    exit_code, output = _invoke(runner, ["status", *_AUTH], mock_cls)
+    assert exit_code == 0
+    assert output == snapshot

--- a/tests/fixtures/auth_status.json
+++ b/tests/fixtures/auth_status.json
@@ -1,0 +1,4 @@
+{
+  "Active": true,
+  "VersionHash": 2645344664
+}

--- a/tests/fixtures/connector.json
+++ b/tests/fixtures/connector.json
@@ -1,0 +1,4 @@
+{
+  "PluggedInEV": false,
+  "PluggedInEVSE": true
+}

--- a/tests/fixtures/ntp_sync.json
+++ b/tests/fixtures/ntp_sync.json
@@ -1,0 +1,3 @@
+{
+  "TimeSynced": true
+}

--- a/tests/fixtures/web_interface_mode.json
+++ b/tests/fixtures/web_interface_mode.json
@@ -1,0 +1,3 @@
+{
+  "Mode": "dashboard"
+}

--- a/tests/test_peblar.py
+++ b/tests/test_peblar.py
@@ -1596,3 +1596,72 @@ def test_charge_limiter_reserved() -> None:
         patched_fixture("ev_interface.json", ChargeCurrentLimitSource="Reserved"),
     )
     assert ev_interface.charge_current_limit_source is ChargeLimiter.RESERVED
+
+
+# ---------------------------------------------------------------------------
+# Device state endpoints
+# ---------------------------------------------------------------------------
+CONNECTOR_URL = BASE_URL + "system/connector"
+NTP_SYNC_URL = BASE_URL + "system/ntp-sync"
+WEB_INTERFACE_MODE_URL = BASE_URL + "system/web-interface-mode"
+AUTH_STATUS_URL = BASE_URL + "auth/status"
+LOGOUT_URL = BASE_URL + "auth/logout"
+
+
+async def test_connector() -> None:
+    """Test the connector endpoint reports what is plugged in."""
+    with aioresponses() as mocked:
+        mocked.get(CONNECTOR_URL, status=200, body=load_fixture("connector.json"))
+        async with Peblar(host=HOST) as peblar:
+            connector = await peblar.connector()
+    assert connector.plugged_in_ev is False
+    assert connector.plugged_in_evse is True
+
+
+async def test_auth_status() -> None:
+    """Test the session status endpoint."""
+    with aioresponses() as mocked:
+        mocked.get(AUTH_STATUS_URL, status=200, body=load_fixture("auth_status.json"))
+        async with Peblar(host=HOST) as peblar:
+            status = await peblar.auth_status()
+    assert status.active is True
+    assert status.version_hash == 2645344664
+
+
+async def test_time_synced() -> None:
+    """Test the NTP sync endpoint returns a plain boolean."""
+    with aioresponses() as mocked:
+        mocked.get(NTP_SYNC_URL, status=200, body=load_fixture("ntp_sync.json"))
+        async with Peblar(host=HOST) as peblar:
+            assert await peblar.time_synced() is True
+
+
+async def test_web_interface_mode() -> None:
+    """Test the web interface mode endpoint returns a plain string."""
+    with aioresponses() as mocked:
+        mocked.get(
+            WEB_INTERFACE_MODE_URL,
+            status=200,
+            body=load_fixture("web_interface_mode.json"),
+        )
+        async with Peblar(host=HOST) as peblar:
+            assert await peblar.web_interface_mode() == "dashboard"
+
+
+async def test_logout_forgets_the_password() -> None:
+    """Test logging out stops the client logging itself back in.
+
+    The 401 retry added for the reauthentication issues relies on a stored
+    password, so an explicit logout has to clear it or the very next
+    request would undo the logout.
+    """
+    with aioresponses() as mocked:
+        mocked.post(LOGIN_URL, status=204, body="", content_type="text/plain")
+        mocked.post(LOGOUT_URL, status=204, body="", content_type="text/plain")
+        mocked.get(USER_CONFIG_URL, status=401, body="", content_type="text/plain")
+
+        async with Peblar(host=HOST) as peblar:
+            await peblar.login(password="test-pass")
+            await peblar.logout()
+            with pytest.raises(PeblarAuthenticationError):
+                await peblar.user_configuration()


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Five endpoints the charger's own web interface uses, none of which appear in Peblar's published OpenAPI spec. I found them by reading the web UI's JavaScript bundle and resolving the axios service classes it builds its request paths from, then confirmed each one against a real charger. The fixtures are the actual responses.

`GET /system/connector` returns `PluggedInEV` and `PluggedInEVSE` separately, which is more than the CP state tells you: it distinguishes a cable in the charger from a cable in the car. `GET /auth/status` reports whether the session is still valid, along with a version hash that changes when the charger's software does. `POST /auth/logout` ends the session. `GET /system/ntp-sync` and `GET /system/web-interface-mode` are small diagnostics.

There is also a `peblar status` command that shows the lot.

Worth noting that `logout()` clears the stored password. The automatic re-login added in #436 keys off that password, so without clearing it the next request would log straight back in and undo the logout. There is a test covering exactly that.

Also raises pylint's `max-public-methods` from 25 to 40. `Peblar` was at 23 and this takes it to 28. It is a facade over a large API, so the method count is inherent rather than a design smell, and raising it once with headroom avoids nudging it again with every endpoint that follows.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
