### PR TITLE
Add autocharge vehicle management

### DIFF
--- a/src/peblar/__init__.py
+++ b/src/peblar/__init__.py
@@ -39,6 +39,7 @@ from .models import (
     PeblarSystem,
     PeblarSystemInformation,
     PeblarUserConfiguration,
+    PeblarVehicleToken,
     PeblarVersions,
 )
 from .peblar import Peblar, PeblarApi
@@ -77,6 +78,7 @@ __all__ = [
     "PeblarSystemInformation",
     "PeblarUnsupportedFirmwareVersionError",
     "PeblarUserConfiguration",
+    "PeblarVehicleToken",
     "PeblarVersions",
     "SmartChargingMode",
     "SolarChargingMode",

--- a/src/peblar/models.py
+++ b/src/peblar/models.py
@@ -258,6 +258,27 @@ class PeblarRfidToken(BaseModel):
 
 
 @dataclass(kw_only=True)
+class PeblarVehicleToken(BaseModel):
+    """Vehicle in the autocharge auth list.
+
+    Autocharge identifies a car by the EVCC ID its ISO 15118 controller
+    presents, which is the vehicle equivalent of an RFID token UID.
+    """
+
+    evcc_id: str = field(metadata=field_options(alias="EvccId"))
+    alias: str = field(metadata=field_options(alias="Alias"))
+
+
+@dataclass(kw_only=True)
+class PeblarAddVehicleToken(BaseModel):
+    """Payload for adding a vehicle to the autocharge auth list."""
+
+    evcc_id: str = field(metadata=field_options(alias="EvccId"))
+    alias: str = field(metadata=field_options(alias="Alias"))
+    authorize: bool = field(default=True, metadata=field_options(alias="Authorize"))
+
+
+@dataclass(kw_only=True)
 class PeblarChargeSessionAuthorization(BaseModel):
     """Object holding the charge session (de)authorization payload.
 

--- a/src/peblar/peblar.py
+++ b/src/peblar/peblar.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import socket
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any, Self, TypedDict
+from typing import TYPE_CHECKING, Any, NotRequired, Self, TypedDict
 
 import orjson
 from aiohttp import ClientResponseError, CookieJar, hdrs
@@ -105,9 +105,14 @@ class _VehicleTokenPayload(TypedDict):
 
 
 class _VehicleTokenListEnvelope(TypedDict):
-    """Autocharge vehicle list response envelope."""
+    """Autocharge vehicle list response envelope.
 
-    VehicleTokens: list[_VehicleTokenPayload]
+    A charger with ISO 15118 turned off answers with a bare null instead
+    of this object, and when it does send the object the key itself can
+    be absent or null, so nothing here is guaranteed.
+    """
+
+    VehicleTokens: NotRequired[list[_VehicleTokenPayload] | None]
 
 
 @dataclass(kw_only=True)

--- a/src/peblar/peblar.py
+++ b/src/peblar/peblar.py
@@ -33,6 +33,7 @@ from .exceptions import (
 )
 from .models import (
     BaseModel,
+    PeblarAddVehicleToken,
     PeblarApiToken,
     PeblarAuthStatus,
     PeblarBuzzerVolume,
@@ -61,6 +62,7 @@ from .models import (
     PeblarSystemInformation,
     PeblarUpdate,
     PeblarUserConfiguration,
+    PeblarVehicleToken,
     PeblarVersions,
     PeblarWebInterfaceMode,
     resolve_led_brightness,
@@ -93,6 +95,19 @@ class _RfidTokenListEnvelope(TypedDict):
     """RFID token list response envelope."""
 
     Tokens: list[_RfidTokenPayload]
+
+
+class _VehicleTokenPayload(TypedDict):
+    """Single vehicle payload returned by the autocharge list endpoint."""
+
+    EvccId: str
+    Alias: str
+
+
+class _VehicleTokenListEnvelope(TypedDict):
+    """Autocharge vehicle list response envelope."""
+
+    VehicleTokens: list[_VehicleTokenPayload]
 
 
 @dataclass(kw_only=True)
@@ -373,6 +388,52 @@ class Peblar:
                 session=[],
             )
         return PeblarMeterHistory.from_json(result)
+
+    async def rfid_token(self, *, uid: str) -> PeblarRfidToken:
+        """Get a single RFID token from the standalone auth list."""
+        result = await self.request(URL("config/auth/standalonelist") / uid)
+        return PeblarRfidToken.from_json(result)
+
+    async def vehicle_tokens(self) -> list[PeblarVehicleToken]:
+        """Get the list of vehicles in the autocharge auth list.
+
+        Autocharge rides on ISO 15118, so a charger with that turned off
+        hands back nothing at all here rather than an empty list.
+        """
+        result = await self.request(URL("config/auth/vehicle-standalonelist"))
+        data: _VehicleTokenListEnvelope | None = orjson.loads(result)
+        if not data:
+            return []
+
+        return [
+            PeblarVehicleToken.from_dict(item)
+            for item in data.get("VehicleTokens") or []
+        ]
+
+    async def add_vehicle_token(
+        self,
+        *,
+        evcc_id: str,
+        alias: str,
+        authorize: bool = True,
+    ) -> None:
+        """Add a vehicle to the autocharge auth list."""
+        await self.request(
+            URL("config/auth/vehicle-standalonelist"),
+            method=hdrs.METH_POST,
+            data=PeblarAddVehicleToken(
+                evcc_id=evcc_id,
+                alias=alias,
+                authorize=authorize,
+            ),
+        )
+
+    async def delete_vehicle_token(self, *, evcc_id: str) -> None:
+        """Remove a vehicle from the autocharge auth list."""
+        await self.request(
+            URL("config/auth/vehicle-standalonelist") / evcc_id,
+            method=hdrs.METH_DELETE,
+        )
 
     async def add_rfid_token(
         self,

--- a/tests/fixtures/vehicle_standalonelist.json
+++ b/tests/fixtures/vehicle_standalonelist.json
@@ -1,0 +1,12 @@
+{
+  "VehicleTokens": [
+    {
+      "Alias": "My EV",
+      "EvccId": "NL-ABC-0123456789-1"
+    },
+    {
+      "Alias": "The other one",
+      "EvccId": "NL-ABC-9876543210-2"
+    }
+  ]
+}

--- a/tests/test_peblar.py
+++ b/tests/test_peblar.py
@@ -1761,3 +1761,84 @@ async def test_set_scheduled_charging() -> None:
         {"CurrentLimit": 0, "StartTime": 0},
         {"CurrentLimit": 10, "StartTime": 1380},
     ]
+
+
+# ---------------------------------------------------------------------------
+# Autocharge vehicle list
+# ---------------------------------------------------------------------------
+VEHICLE_LIST_URL = BASE_URL + "config/auth/vehicle-standalonelist"
+
+
+async def test_rfid_token_single() -> None:
+    """Test fetching one RFID token by its UID."""
+    with aioresponses() as mocked:
+        mocked.get(
+            STANDALONELIST_URL + "/0123456789ABCD",
+            status=200,
+            body=orjson.dumps(
+                {
+                    "RfidTokenUid": "0123456789ABCD",
+                    "RfidTokenDescription": "My RFID Card",
+                }
+            ),
+        )
+        async with Peblar(host=HOST) as peblar:
+            token = await peblar.rfid_token(uid="0123456789ABCD")
+    assert token.rfid_token_description == "My RFID Card"
+
+
+async def test_vehicle_tokens() -> None:
+    """Test listing the autocharge vehicles."""
+    with aioresponses() as mocked:
+        mocked.get(
+            VEHICLE_LIST_URL,
+            status=200,
+            body=load_fixture("vehicle_standalonelist.json"),
+        )
+        async with Peblar(host=HOST) as peblar:
+            vehicles = await peblar.vehicle_tokens()
+    assert len(vehicles) == 2
+    assert vehicles[0].evcc_id == "NL-ABC-0123456789-1"
+    assert vehicles[0].alias == "My EV"
+
+
+@pytest.mark.parametrize("body", ["null", "{}", '{"VehicleTokens": null}'])
+async def test_vehicle_tokens_empty(body: str) -> None:
+    """Test a charger without autocharge hands back nothing usable.
+
+    A charger with ISO 15118 disabled answers with a bare null rather
+    than an empty list, which is what a real one was seen doing.
+    """
+    with aioresponses() as mocked:
+        mocked.get(VEHICLE_LIST_URL, status=200, body=body)
+        async with Peblar(host=HOST) as peblar:
+            assert await peblar.vehicle_tokens() == []
+
+
+async def test_add_vehicle_token() -> None:
+    """Test adding a vehicle to the autocharge auth list."""
+    with aioresponses() as mocked:
+        mocked.post(VEHICLE_LIST_URL, status=200, body="", content_type="text/plain")
+        async with Peblar(host=HOST) as peblar:
+            await peblar.add_vehicle_token(
+                evcc_id="NL-ABC-0123456789-1",
+                alias="My EV",
+            )
+    assert request_payload(mocked) == {
+        "EvccId": "NL-ABC-0123456789-1",
+        "Alias": "My EV",
+        "Authorize": True,
+    }
+
+
+async def test_delete_vehicle_token() -> None:
+    """Test removing a vehicle from the autocharge auth list."""
+    with aioresponses() as mocked:
+        mocked.delete(
+            VEHICLE_LIST_URL + "/NL-ABC-0123456789-1",
+            status=200,
+            body="",
+            content_type="text/plain",
+        )
+        async with Peblar(host=HOST) as peblar:
+            await peblar.delete_vehicle_token(evcc_id="NL-ABC-0123456789-1")


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Autocharge lets a car identify itself over ISO 15118 instead of needing an RFID token, and the charger keeps a separate auth list for it. Since #441 this library can be told about a vehicle through the `/vehicle/tokenfound` websocket topic, but had no way to manage the list that token is matched against. These methods mirror the existing RFID token ones: list, add, delete.

Also adds `rfid_token(uid)` for fetching a single RFID token, which the web interface has and this library did not.

The payload shapes come from the web interface's own request building code rather than guesswork: `POST` takes `EvccId`, `Alias` and `Authorize`, `DELETE` addresses the vehicle by its EVCC ID, and the list comes back wrapped in a `VehicleTokens` envelope.

Worth being explicit about test coverage here. The charger I have available runs with `Iso15118CommunicationEnable` off, so its vehicle list endpoint answers with a bare `null` rather than an empty list. That behaviour is verified against real hardware and is why `vehicle_tokens()` treats a null body as an empty list instead of failing. The add and delete paths are unit tested only, since there is no way to exercise them without autocharge enabled.

`/config/auth/vehicle-latest` is deliberately left out. It returns 403 on a charger without ISO 15118, and the web interface parses its timestamp with `new Date()`, which accepts both ISO strings and epoch milliseconds. Without a response to look at, picking one would be a guess baked into a typed model.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Follows up on #441, which added the vehicle token websocket topic.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
