### PR TITLE
Add websocket support

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,36 @@ if __name__ == "__main__":
     asyncio.run(main())
 ```
 
+### Live updates
+
+The charger also pushes changes over a websocket, which beats polling and keeps you clear of the rate limit entirely:
+
+```python
+import asyncio
+
+from peblar import Peblar, PeblarSessionStatus
+
+
+async def main() -> None:
+    """Show an example of following a Peblar charging session live."""
+    async with Peblar(host="192.168.1.123") as peblar:
+        await peblar.login(password="Sup3rS3cr3t!")
+
+        def on_session(session: PeblarSessionStatus) -> None:
+            print(session.state, session.meter_data)
+
+        async with peblar.websocket() as websocket:
+            # The current state arrives immediately, then on every change
+            await websocket.subscribe_session_status(on_session)
+            await websocket.listen()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+The CLI wraps this in `peblar watch`.
+
 ## Changelog & releases
 
 This repository keeps a change log using [GitHub's releases][releases]

--- a/src/peblar/__init__.py
+++ b/src/peblar/__init__.py
@@ -8,9 +8,11 @@ from .const import (
     CPState,
     LedBrightness,
     LedIntensityMode,
+    SessionState,
     SmartChargingMode,
     SolarChargingMode,
     SoundVolume,
+    WebsocketTopic,
 )
 from .exceptions import (
     PeblarAuthenticationError,
@@ -35,14 +37,18 @@ from .models import (
     PeblarScheduleSlot,
     PeblarSessionGraph,
     PeblarSessionGraphPoint,
+    PeblarSessionMeterData,
+    PeblarSessionStatus,
     PeblarSetUserConfiguration,
     PeblarSystem,
     PeblarSystemInformation,
+    PeblarTokenFound,
     PeblarUserConfiguration,
     PeblarVehicleToken,
     PeblarVersions,
 )
 from .peblar import Peblar, PeblarApi
+from .websocket import PeblarWebsocket, session_status_topic
 
 __all__ = [
     "MINIMUM_FIRMWARE_VERSION_LOCAL_REST_API",
@@ -73,14 +79,21 @@ __all__ = [
     "PeblarScheduledCharging",
     "PeblarSessionGraph",
     "PeblarSessionGraphPoint",
+    "PeblarSessionMeterData",
+    "PeblarSessionStatus",
     "PeblarSetUserConfiguration",
     "PeblarSystem",
     "PeblarSystemInformation",
+    "PeblarTokenFound",
     "PeblarUnsupportedFirmwareVersionError",
     "PeblarUserConfiguration",
     "PeblarVehicleToken",
     "PeblarVersions",
+    "PeblarWebsocket",
+    "SessionState",
     "SmartChargingMode",
     "SolarChargingMode",
     "SoundVolume",
+    "WebsocketTopic",
+    "session_status_topic",
 ]

--- a/src/peblar/cli/__init__.py
+++ b/src/peblar/cli/__init__.py
@@ -28,6 +28,7 @@ from peblar.const import (
     CPState,
     LedBrightness,
     PackageType,
+    SessionState,
     SmartChargingMode,
     SoundVolume,
 )
@@ -43,6 +44,7 @@ from peblar.models import (
     PeblarMeterHistory,
     PeblarMeterHistorySession,
     PeblarRfidToken,
+    PeblarSessionStatus,
     PeblarSetUserConfiguration,
 )
 from peblar.peblar import Peblar
@@ -51,6 +53,16 @@ from .async_typer import AsyncTyper
 
 cli = AsyncTyper(help="Peblar CLI", no_args_is_help=True, add_completion=False)
 console = Console()
+
+SESSION_STATE_LABELS = {
+    SessionState.AVAILABLE: "[green]Available",
+    SessionState.CHARGING: "[green bold]Charging",
+    SessionState.FAULTED: "[red bold]Faulted",
+    SessionState.FINISHING: "[yellow]Finishing",
+    SessionState.PREPARING_AUTHORIZED: "[cyan]Waiting for cable",
+    SessionState.PREPARING_PLUGGED_IN: "[cyan]Waiting for authorization",
+    SessionState.UNAVAILABLE: "[red]Unavailable",
+}
 
 WEEKDAY_NAMES = (
     "Monday",
@@ -2314,6 +2326,59 @@ async def energy_history(
         table.add_row(period, f"{sum(month.energy) / 1000:.1f} kWh")
 
     console.print(table)
+
+
+@cli.command("watch")
+async def watch(
+    host: Annotated[
+        str,
+        typer.Option(
+            help="Peblar charger IP address or hostname",
+            prompt="Host address",
+            show_default=False,
+            envvar="PEBLAR_HOST",
+        ),
+    ],
+    password: Annotated[
+        str,
+        typer.Option(
+            help="Peblar charger login password",
+            prompt="Password",
+            show_default=False,
+            hide_input=True,
+            envvar="PEBLAR_PASSWORD",
+        ),
+    ],
+    quiet: Annotated[bool, QUIET_OPTION] = False,  # noqa: ARG001  # pylint: disable=unused-argument
+) -> None:
+    """Stream live charging session updates until interrupted.
+
+    The charger pushes these over a websocket, so this costs one
+    connection instead of hammering the API with polls.
+    """
+    async with Peblar(host=host) as peblar:
+        await peblar.login(password=password)
+
+        def on_session(session: PeblarSessionStatus) -> None:
+            state = SESSION_STATE_LABELS.get(session.state, str(session.state))
+
+            if (readings := session.meter_data) is None:
+                console.print(state)
+                return
+
+            console.print(
+                f"{state}[/] [bold]{readings.instantaneous_power_total}W[/] "
+                f"session [bold]{readings.session_energy / 1000:.3f} kWh[/] "
+                f"total [bold]{readings.total_energy / 1000:.1f} kWh[/]"
+            )
+
+        async with peblar.websocket() as websocket:
+            # Announce first: the charger pushes the current state during
+            # the subscribe, so the banner would otherwise land second.
+            console.print("[cyan]Watching for updates, press Ctrl+C to stop...")
+            await websocket.subscribe_session_status(on_session)
+            with contextlib.suppress(asyncio.CancelledError, KeyboardInterrupt):
+                await websocket.listen()
 
 
 @cli.command("scan")

--- a/src/peblar/const.py
+++ b/src/peblar/const.py
@@ -103,6 +103,52 @@ class SmartChargingMode(StrEnum):
     "Charge only within the defined schedule."
 
 
+class SessionState(StrEnum):
+    """Peblar charging session state.
+
+    Pushed over the websocket. These are the values the charger's own web
+    interface knows how to render.
+    """
+
+    AVAILABLE = "available"
+    """Idle and ready, nothing plugged in."""
+
+    CHARGING = "charging"
+    """Actively delivering energy to the EV."""
+
+    FAULTED = "faulted"
+    """The charger detected a fault."""
+
+    FINISHING = "finishing"
+    """The session is wrapping up."""
+
+    PREPARING_AUTHORIZED = "preparingAuthorized"
+    """Authorized, waiting for a cable."""
+
+    PREPARING_PLUGGED_IN = "preparingPluggedIn"
+    """Cable plugged in, waiting for authorization."""
+
+    UNAVAILABLE = "unavailable"
+    """Not available for charging."""
+
+
+class WebsocketTopic(StrEnum):
+    """Peblar websocket topics that take no parameters.
+
+    The session status topic is per connector, see
+    PeblarWebsocket.subscribe_session_status().
+    """
+
+    RFID_TOKEN_FOUND = "/rfid/tokenfound"  # noqa: S105
+    """An RFID token was held against the reader."""
+
+    STATUS_CHANGED = "/system/diagnostics/statuschanged"
+    """An error or warning signal became active or cleared."""
+
+    VEHICLE_TOKEN_FOUND = "/vehicle/tokenfound"  # noqa: S105
+    """A vehicle identified itself for autocharge."""
+
+
 class ChargeLimiter(StrEnum):
     """Peblar charge limiter."""
 

--- a/src/peblar/models.py
+++ b/src/peblar/models.py
@@ -21,6 +21,7 @@ from .const import (
     LedBrightness,
     LedIntensityMode,
     PackageType,
+    SessionState,
     SmartChargingMode,
     SolarChargingMode,
     SoundVolume,
@@ -997,6 +998,48 @@ class PeblarScheduledCharging(BaseModel):
             5: self.saturday,
             6: self.sunday,
         }
+
+
+@dataclass(kw_only=True)
+class PeblarSessionMeterData(BaseModel):
+    """Meter readings carried along with a session status event."""
+
+    instantaneous_power: list[int] = field(
+        metadata=field_options(alias="instantaneousPower")
+    )
+    """Instantaneous power per phase, in Watts."""
+
+    session_energy: int = field(metadata=field_options(alias="sessionEnergy"))
+    """Energy delivered in the current or last session, in Wh."""
+
+    total_energy: int = field(metadata=field_options(alias="totalEnergy"))
+    """Lifetime energy delivered by the charger, in Wh."""
+
+    @property
+    def instantaneous_power_total(self) -> int:
+        """Return the instantaneous power over all phases, in Watts."""
+        return sum(self.instantaneous_power)
+
+
+@dataclass(kw_only=True)
+class PeblarSessionStatus(BaseModel):
+    """Object holding a charging session status event.
+
+    Pushed over the websocket whenever the session changes, and once right
+    after subscribing.
+    """
+
+    state: SessionState = field(metadata=field_options(alias="state"))
+    meter_data: PeblarSessionMeterData | None = field(
+        default=None, metadata=field_options(alias="meterData")
+    )
+
+
+@dataclass(kw_only=True)
+class PeblarTokenFound(BaseModel):
+    """Object holding an RFID or vehicle token event."""
+
+    token_id: str = field(metadata=field_options(alias="tokenId"))
 
 
 @dataclass(kw_only=True)

--- a/src/peblar/peblar.py
+++ b/src/peblar/peblar.py
@@ -68,6 +68,7 @@ from .models import (
     resolve_led_brightness,
 )
 from .utils import build_error_message, get_awesome_version
+from .websocket import PeblarWebsocket
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Coroutine
@@ -487,6 +488,17 @@ class Peblar:
         """Get information about the Peblar charger."""
         result = await self.request(URL("system/info"))
         return PeblarSystemInformation.from_json(result)
+
+    def websocket(self) -> PeblarWebsocket:
+        """Get a websocket client for this charger's live event stream.
+
+        Shares the logged-in session, so call login() first.
+        """
+        if self.session is None:
+            msg = "Log in to the Peblar charger before opening a websocket."
+            raise PeblarError(msg)
+
+        return PeblarWebsocket(host=self.host, session=self.session)
 
     async def logout(self) -> None:
         """Log out of the Peblar charger, ending the current session.

--- a/src/peblar/websocket.py
+++ b/src/peblar/websocket.py
@@ -1,0 +1,239 @@
+"""Asynchronous Python client for Peblar EV chargers."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Self
+
+from aiohttp import ClientError, WSMsgType
+from yarl import URL
+
+from .const import WebsocketTopic
+from .exceptions import (
+    PeblarConnectionError,
+    PeblarError,
+)
+from .models import PeblarSessionStatus, PeblarTokenFound
+
+if TYPE_CHECKING:
+    from aiohttp import ClientSession, ClientWebSocketResponse
+
+EventCallback = Callable[[dict[str, Any]], None]
+
+
+def session_status_topic(connector: int = 1) -> str:
+    """Return the session status topic for a connector."""
+    return f"/session/status/connector/{connector}"
+
+
+@dataclass(kw_only=True)
+class PeblarWebsocket:
+    """Live event stream from a Peblar charger.
+
+    The charger pushes changes instead of making you poll for them, which
+    also keeps you clear of the API's rate limit. It authenticates with the
+    same session cookie as the web API, so this is handed out by
+    Peblar.websocket() once you are logged in.
+
+    Subscriptions survive nothing: if the connection drops, resubscribe
+    after reconnecting.
+    """
+
+    host: str
+    session: ClientSession
+    request_timeout: float = 8
+
+    _client: ClientWebSocketResponse | None = field(default=None, init=False)
+    _callbacks: dict[str, EventCallback] = field(default_factory=dict, init=False)
+    _pending: dict[str, asyncio.Future[None]] = field(default_factory=dict, init=False)
+    _reader: asyncio.Task[None] | None = field(default=None, init=False)
+
+    def __post_init__(self) -> None:
+        """Initialize the websocket object."""
+        self.url = URL.build(scheme="ws", host=self.host, path="/api/v1/ws")
+
+    @property
+    def connected(self) -> bool:
+        """Return whether the websocket is currently connected."""
+        return self._client is not None and not self._client.closed
+
+    async def connect(self) -> None:
+        """Open the websocket connection to the charger."""
+        if self.connected:
+            return
+
+        try:
+            self._client = await self.session.ws_connect(self.url)
+        except (ClientError, OSError) as exception:
+            msg = "Error occurred while connecting to the Peblar charger websocket"
+            raise PeblarConnectionError(msg) from exception
+
+        self._reader = asyncio.create_task(self._read_messages())
+
+    async def subscribe(self, topic: str, callback: EventCallback) -> None:
+        """Subscribe to a topic, handing every event to the callback.
+
+        The callback receives the raw event payload. For the topics with a
+        known shape, prefer the typed helpers below.
+        """
+        # Registered before subscribing, not after: the charger pushes the
+        # current state immediately behind the acknowledgement, and that
+        # first event lands while we are still waiting on the ack.
+        self._callbacks[topic] = callback
+        try:
+            await self._send_action("subscribe", topic)
+        except PeblarError:
+            self._callbacks.pop(topic, None)
+            raise
+
+    async def subscribe_session_status(
+        self,
+        callback: Callable[[PeblarSessionStatus], None],
+        *,
+        connector: int = 1,
+    ) -> None:
+        """Subscribe to charging session updates for a connector.
+
+        The charger sends the current status right after subscribing, so
+        the callback fires once without anything having changed.
+        """
+        await self.subscribe(
+            session_status_topic(connector),
+            lambda data: callback(PeblarSessionStatus.from_dict(data)),
+        )
+
+    async def subscribe_token_found(
+        self,
+        callback: Callable[[PeblarTokenFound], None],
+        *,
+        topic: WebsocketTopic = WebsocketTopic.RFID_TOKEN_FOUND,
+    ) -> None:
+        """Subscribe to tokens being presented to the charger."""
+        await self.subscribe(
+            topic,
+            lambda data: callback(PeblarTokenFound.from_dict(data)),
+        )
+
+    async def unsubscribe(self, topic: str) -> None:
+        """Unsubscribe from a topic."""
+        await self._send_action("unsubscribe", topic)
+        self._callbacks.pop(topic, None)
+
+    async def listen(self) -> None:
+        """Block until the connection closes.
+
+        Raises whatever knocked the connection over, so a caller can treat
+        this as the lifetime of the connection and reconnect when it ends.
+
+        Listening is observing, not owning: cancelling this leaves the
+        connection up and events still flowing to their callbacks. Call
+        disconnect() to actually tear it down.
+        """
+        if self._reader is None:
+            msg = "Not connected to the Peblar charger websocket"
+            raise PeblarError(msg)
+
+        await asyncio.shield(self._reader)
+
+    async def disconnect(self) -> None:
+        """Close the websocket connection."""
+        if self._reader is not None:
+            self._reader.cancel()
+            # The reader owns the socket, so let it finish unwinding first.
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._reader
+            self._reader = None
+
+        if self._client is not None:
+            await self._client.close()
+            self._client = None
+
+        self._callbacks.clear()
+
+    async def _send_action(self, action: str, topic: str) -> None:
+        """Send a subscribe or unsubscribe request and wait for the result."""
+        if self._client is None or not self.connected:
+            msg = "Not connected to the Peblar charger websocket"
+            raise PeblarError(msg)
+
+        future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
+        self._pending[topic] = future
+
+        try:
+            await self._client.send_json({"action": action, "topic": topic})
+            async with asyncio.timeout(self.request_timeout):
+                await future
+        except TimeoutError as exception:
+            msg = f"Timeout while trying to {action} to topic {topic}"
+            raise PeblarConnectionError(msg) from exception
+        except (ClientError, OSError) as exception:
+            msg = f"Error occurred while trying to {action} to topic {topic}"
+            raise PeblarConnectionError(msg) from exception
+        finally:
+            self._pending.pop(topic, None)
+
+    async def _read_messages(self) -> None:
+        """Dispatch incoming messages until the connection closes."""
+        if self._client is None:
+            return
+
+        try:
+            async for message in self._client:
+                if message.type is not WSMsgType.TEXT:
+                    continue
+                self._handle_message(message.json())
+        finally:
+            # Nobody is going to answer a pending subscribe any more.
+            for future in self._pending.values():
+                if not future.done():
+                    future.set_exception(
+                        PeblarConnectionError(
+                            "Peblar charger websocket closed while waiting for a result"
+                        )
+                    )
+
+    def _handle_message(self, message: dict[str, Any]) -> None:
+        """Route a single message to a pending request or a subscriber."""
+        topic = message.get("topic")
+        if not topic:
+            return
+
+        data = message.get("data", {})
+
+        if message.get("type") == "result":
+            if (future := self._pending.get(topic)) and not future.done():
+                if data.get("status") == "ok":
+                    future.set_result(None)
+                else:
+                    reason = data.get("message", "no reason given")
+                    future.set_exception(
+                        PeblarError(f"Peblar charger rejected topic {topic}: {reason}")
+                    )
+            return
+
+        if message.get("type") == "event" and (callback := self._callbacks.get(topic)):
+            callback(data)
+
+    async def __aenter__(self) -> Self:
+        """Async enter.
+
+        Returns
+        -------
+            The connected PeblarWebsocket object.
+
+        """
+        await self.connect()
+        return self
+
+    async def __aexit__(self, *_exc_info: object) -> None:
+        """Async exit.
+
+        Args:
+        ----
+            _exc_info: Exec type.
+
+        """
+        await self.disconnect()

--- a/src/peblar/websocket.py
+++ b/src/peblar/websocket.py
@@ -14,6 +14,7 @@ from yarl import URL
 from .const import WebsocketTopic
 from .exceptions import (
     PeblarConnectionError,
+    PeblarConnectionTimeoutError,
     PeblarError,
 )
 from .models import PeblarSessionStatus, PeblarTokenFound
@@ -76,7 +77,10 @@ class PeblarWebsocket:
 
         try:
             self._client = await self.session.ws_connect(self.url)
-        except (ClientError, OSError) as exception:
+        except TimeoutError as exception:
+            msg = "Timeout occurred while connecting to the Peblar charger websocket"
+            raise PeblarConnectionTimeoutError(msg) from exception
+        except (ClientError, OSError, RuntimeError) as exception:
             msg = "Error occurred while connecting to the Peblar charger websocket"
             raise PeblarConnectionError(msg) from exception
 
@@ -85,8 +89,10 @@ class PeblarWebsocket:
     async def subscribe(self, topic: str, callback: EventCallback) -> None:
         """Subscribe to a topic, handing every event to the callback.
 
-        The callback receives the raw event payload. For the topics with a
-        known shape, prefer the typed helpers below.
+        The callback receives the event payload, normalised to a mapping:
+        a topic that sends anything else, null included, arrives as an
+        empty dict. For the topics with a known shape, prefer the typed
+        helpers below.
 
         Keep the callback from raising. One reader serves every
         subscription on the connection, so an exception escaping a
@@ -164,7 +170,10 @@ class PeblarWebsocket:
             self._reader = None
 
         if self._client is not None:
-            await self._client.close()
+            # Teardown is called from finally blocks; it does not get to
+            # raise on the way out.
+            with contextlib.suppress(Exception):
+                await self._client.close()
             self._client = None
 
         self._callbacks.clear()
@@ -189,7 +198,7 @@ class PeblarWebsocket:
         except TimeoutError as exception:
             msg = f"Timeout on the {action} request for topic {topic}"
             raise PeblarConnectionError(msg) from exception
-        except (ClientError, OSError) as exception:
+        except (ClientError, OSError, RuntimeError) as exception:
             msg = f"Error occurred during the {action} request for topic {topic}"
             raise PeblarConnectionError(msg) from exception
         finally:
@@ -224,7 +233,10 @@ class PeblarWebsocket:
             # with it rather than lingering open with no reader. On
             # cancellation disconnect() is already doing the closing.
             if not cancelled and not self._client.closed:
-                await self._client.close()
+                # Never let a failing close replace whatever stopped the
+                # reader, since that is the error listen() reports.
+                with contextlib.suppress(Exception):
+                    await self._client.close()
 
             self._callbacks.clear()
 

--- a/src/peblar/websocket.py
+++ b/src/peblar/websocket.py
@@ -57,8 +57,17 @@ class PeblarWebsocket:
 
     @property
     def connected(self) -> bool:
-        """Return whether the websocket is currently connected."""
-        return self._client is not None and not self._client.closed
+        """Return whether the websocket is up and dispatching events.
+
+        A reader that has stopped means nothing reaches the callbacks any
+        more, so an open socket on its own does not count as connected.
+        """
+        return (
+            self._client is not None
+            and not self._client.closed
+            and self._reader is not None
+            and not self._reader.done()
+        )
 
     async def connect(self) -> None:
         """Open the websocket connection to the charger."""
@@ -78,6 +87,11 @@ class PeblarWebsocket:
 
         The callback receives the raw event payload. For the topics with a
         known shape, prefer the typed helpers below.
+
+        Keep the callback from raising. One reader serves every
+        subscription on the connection, so an exception escaping a
+        callback stops all of them; listen() re-raises it and connected
+        turns False, but the connection is gone either way.
         """
         # Registered before subscribing, not after: the charger pushes the
         # current state immediately behind the acknowledgement, and that
@@ -142,8 +156,10 @@ class PeblarWebsocket:
         """Close the websocket connection."""
         if self._reader is not None:
             self._reader.cancel()
-            # The reader owns the socket, so let it finish unwinding first.
-            with contextlib.suppress(asyncio.CancelledError):
+            # The reader owns the socket, so let it finish unwinding
+            # first. Whatever it died of is reported by listen(), never by
+            # teardown, which has to stay safe to call from a finally.
+            with contextlib.suppress(asyncio.CancelledError, Exception):
                 await self._reader
             self._reader = None
 

--- a/src/peblar/websocket.py
+++ b/src/peblar/websocket.py
@@ -177,6 +177,7 @@ class PeblarWebsocket:
             self._client = None
 
         self._callbacks.clear()
+        self._pending.clear()
 
     async def _send_action(self, action: str, topic: str) -> None:
         """Send a subscribe or unsubscribe request and wait for the result."""
@@ -197,7 +198,7 @@ class PeblarWebsocket:
                 await future
         except TimeoutError as exception:
             msg = f"Timeout on the {action} request for topic {topic}"
-            raise PeblarConnectionError(msg) from exception
+            raise PeblarConnectionTimeoutError(msg) from exception
         except (ClientError, OSError, RuntimeError) as exception:
             msg = f"Error occurred during the {action} request for topic {topic}"
             raise PeblarConnectionError(msg) from exception

--- a/src/peblar/websocket.py
+++ b/src/peblar/websocket.py
@@ -159,6 +159,10 @@ class PeblarWebsocket:
             msg = "Not connected to the Peblar charger websocket"
             raise PeblarError(msg)
 
+        if topic in self._pending:
+            msg = f"A request for topic {topic} is already in flight"
+            raise PeblarError(msg)
+
         future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
         self._pending[topic] = future
 
@@ -184,7 +188,16 @@ class PeblarWebsocket:
             async for message in self._client:
                 if message.type is not WSMsgType.TEXT:
                     continue
-                self._handle_message(message.json())
+
+                # Anything unparseable is skipped rather than allowed to
+                # kill the reader, which would silently stop every
+                # subscription on this connection.
+                try:
+                    payload = message.json()
+                except ValueError:
+                    continue
+
+                self._handle_message(payload)
         finally:
             # Nobody is going to answer a pending subscribe any more.
             for future in self._pending.values():
@@ -195,13 +208,23 @@ class PeblarWebsocket:
                         )
                     )
 
-    def _handle_message(self, message: dict[str, Any]) -> None:
-        """Route a single message to a pending request or a subscriber."""
+    def _handle_message(self, message: Any) -> None:
+        """Route a single message to a pending request or a subscriber.
+
+        Nothing in here trusts the shape of what arrived. A surprising
+        payload gets dropped, because raising would end the reader task
+        and take every subscription down with it.
+        """
+        if not isinstance(message, dict):
+            return
+
         topic = message.get("topic")
         if not topic:
             return
 
-        data = message.get("data", {})
+        data = message.get("data")
+        if not isinstance(data, dict):
+            data = {}
 
         if message.get("type") == "result":
             if (future := self._pending.get(topic)) and not future.done():

--- a/src/peblar/websocket.py
+++ b/src/peblar/websocket.py
@@ -150,13 +150,23 @@ class PeblarWebsocket:
 
         Listening is observing, not owning: cancelling this leaves the
         connection up and events still flowing to their callbacks. Call
-        disconnect() to actually tear it down.
+        disconnect() to actually tear it down, which returns from here
+        normally, since asking for a shutdown is not a failure.
         """
-        if self._reader is None:
+        reader = self._reader
+        if reader is None:
             msg = "Not connected to the Peblar charger websocket"
             raise PeblarError(msg)
 
-        await asyncio.shield(self._reader)
+        try:
+            await asyncio.shield(reader)
+        except asyncio.CancelledError:
+            # disconnect() cancels the reader. Only a cancellation aimed
+            # at this call is worth re-raising: handing back a
+            # CancelledError nobody asked for would make a caller that
+            # was never cancelled look like it was.
+            if not reader.cancelled():
+                raise
 
     async def disconnect(self) -> None:
         """Close the websocket connection."""

--- a/src/peblar/websocket.py
+++ b/src/peblar/websocket.py
@@ -187,10 +187,10 @@ class PeblarWebsocket:
             async with asyncio.timeout(self.request_timeout):
                 await future
         except TimeoutError as exception:
-            msg = f"Timeout while trying to {action} to topic {topic}"
+            msg = f"Timeout on the {action} request for topic {topic}"
             raise PeblarConnectionError(msg) from exception
         except (ClientError, OSError) as exception:
-            msg = f"Error occurred while trying to {action} to topic {topic}"
+            msg = f"Error occurred during the {action} request for topic {topic}"
             raise PeblarConnectionError(msg) from exception
         finally:
             self._pending.pop(topic, None)
@@ -200,6 +200,7 @@ class PeblarWebsocket:
         if self._client is None:
             return
 
+        cancelled = False
         try:
             async for message in self._client:
                 if message.type is not WSMsgType.TEXT:
@@ -214,7 +215,19 @@ class PeblarWebsocket:
                     continue
 
                 self._handle_message(payload)
+        except asyncio.CancelledError:
+            cancelled = True
+            raise
         finally:
+            # The reader owns the socket. If it stops on its own then
+            # nothing is consuming frames any more, so the connection goes
+            # with it rather than lingering open with no reader. On
+            # cancellation disconnect() is already doing the closing.
+            if not cancelled and not self._client.closed:
+                await self._client.close()
+
+            self._callbacks.clear()
+
             # Nobody is going to answer a pending subscribe any more.
             for future in self._pending.values():
                 if not future.done():

--- a/src/peblar/websocket.py
+++ b/src/peblar/websocket.py
@@ -189,7 +189,7 @@ class PeblarWebsocket:
                 if message.type is not WSMsgType.TEXT:
                     continue
 
-                # Anything unparseable is skipped rather than allowed to
+                # Anything unparsable is skipped rather than allowed to
                 # kill the reader, which would silently stop every
                 # subscription on this connection.
                 try:

--- a/tests/cli/__snapshots__/test_cli.ambr
+++ b/tests/cli/__snapshots__/test_cli.ambr
@@ -185,6 +185,11 @@
       'password',
       'quiet',
     ]),
+    'watch': list([
+      'host',
+      'password',
+      'quiet',
+    ]),
   })
 # ---
 # name: test_config

--- a/tests/test_peblar.py
+++ b/tests/test_peblar.py
@@ -8,6 +8,7 @@ import orjson
 import pytest
 from aiohttp import ClientConnectionError, ClientSession
 from aioresponses import aioresponses
+from yarl import URL
 
 from peblar import Peblar
 from peblar.const import (
@@ -1842,3 +1843,25 @@ async def test_delete_vehicle_token() -> None:
         )
         async with Peblar(host=HOST) as peblar:
             await peblar.delete_vehicle_token(evcc_id="NL-ABC-0123456789-1")
+
+
+# ---------------------------------------------------------------------------
+# Websocket accessor
+# ---------------------------------------------------------------------------
+async def test_websocket_requires_a_session() -> None:
+    """Test asking for a websocket before logging in is refused."""
+    peblar = Peblar(host=HOST)
+    with pytest.raises(PeblarError, match="Log in to the Peblar charger"):
+        peblar.websocket()
+    await peblar.close()
+
+
+async def test_websocket_shares_the_logged_in_session() -> None:
+    """Test the websocket reuses the session that carries the login cookie."""
+    with aioresponses() as mocked:
+        mocked.post(LOGIN_URL, status=204, body="", content_type="text/plain")
+        async with Peblar(host=HOST) as peblar:
+            await peblar.login(password="test-pass")
+            websocket = peblar.websocket()
+    assert websocket.session is peblar.session
+    assert websocket.url == URL(f"ws://{HOST}/api/v1/ws")

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -547,3 +547,36 @@ async def test_disconnect_clears_in_flight_bookkeeping(
     # Reconnecting and asking for the same topic again is fine.
     await websocket.connect()
     await websocket.subscribe_session_status(lambda _: None)
+
+
+async def test_disconnect_ends_listen_cleanly(websocket: PeblarWebsocket) -> None:
+    """Test asking for a shutdown is not reported as a failure.
+
+    A caller awaiting listen() in its own task was never cancelled, so
+    handing it a CancelledError because someone else called disconnect()
+    would make it look like it was.
+    """
+    await websocket.connect()
+    listener = asyncio.create_task(websocket.listen())
+    await asyncio.sleep(0.05)
+
+    await websocket.disconnect()
+    await listener  # returns, does not raise
+
+    assert websocket.connected is False
+
+
+async def test_cancelling_listen_still_cancels_the_caller(
+    websocket: PeblarWebsocket,
+) -> None:
+    """Test a cancellation aimed at listen() is still delivered."""
+    await websocket.connect()
+    listener = asyncio.create_task(websocket.listen())
+    await asyncio.sleep(0.05)
+
+    listener.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await listener
+
+    # The connection is untouched, listening is only observing.
+    assert websocket.connected is True

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -272,7 +272,7 @@ async def test_subscribe_times_out(websocket: PeblarWebsocket) -> None:
     """Test a charger that never acknowledges surfaces as a timeout."""
     websocket.request_timeout = 0.1
     await websocket.connect()
-    with pytest.raises(PeblarConnectionError, match="Timeout while trying"):
+    with pytest.raises(PeblarConnectionError, match="Timeout on the subscribe request"):
         await websocket.subscribe(SILENT_TOPIC, lambda _: None)
 
 
@@ -312,7 +312,9 @@ async def test_send_failure_surfaces_as_connection_error(
 
     # pylint: disable-next=protected-access
     monkeypatch.setattr(websocket._client, "send_json", boom)
-    with pytest.raises(PeblarConnectionError, match="Error occurred while trying"):
+    with pytest.raises(
+        PeblarConnectionError, match="Error occurred during the subscribe request"
+    ):
         await websocket.subscribe(SESSION_TOPIC, lambda _: None)
 
 
@@ -422,3 +424,47 @@ async def test_context_manager_exit_survives_a_dead_reader(
         await asyncio.sleep(0.05)
 
     assert websocket.connected is False
+
+
+async def test_reader_closes_the_socket_when_it_stops(
+    websocket: PeblarWebsocket,
+) -> None:
+    """Test a stopped reader does not leave the socket open behind it.
+
+    The reader owns the socket, so if it goes the connection goes too
+    rather than lingering with nothing consuming frames.
+    """
+    await websocket.connect()
+
+    def boom(_data: dict[str, Any]) -> None:
+        msg = "consumer bug"
+        raise RuntimeError(msg)
+
+    await websocket.subscribe_session_status(lambda _: boom({}))
+
+    # Wait for the reader to finish unwinding rather than racing it.
+    with pytest.raises(RuntimeError, match="consumer bug"):
+        await websocket.listen()
+
+    client = websocket._client  # pylint: disable=protected-access
+    assert client is not None
+    assert client.closed is True
+    # Subscriptions went with it.
+    assert not websocket._callbacks  # pylint: disable=protected-access
+
+
+async def test_cancelling_listen_leaves_the_socket_open(
+    websocket: PeblarWebsocket,
+) -> None:
+    """Test cancelling the observer does not close what it was watching."""
+    await websocket.connect()
+    listener = asyncio.create_task(websocket.listen())
+    await asyncio.sleep(0)
+    listener.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await listener
+
+    client = websocket._client  # pylint: disable=protected-access
+    assert client is not None
+    assert client.closed is False
+    assert websocket.connected is True

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -1,0 +1,312 @@
+"""Tests for `peblar.websocket`."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from aiohttp import ClientError, ClientSession, WSMsgType, web
+from aiohttp.test_utils import TestServer
+from yarl import URL
+
+from peblar.const import SessionState, WebsocketTopic
+from peblar.exceptions import PeblarConnectionError, PeblarError
+from peblar.websocket import PeblarWebsocket, session_status_topic
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+    from peblar.models import PeblarSessionStatus, PeblarTokenFound
+
+SESSION_TOPIC = session_status_topic()
+REJECTED_TOPIC = "/nope"
+SILENT_TOPIC = "/silent"
+BINARY_TOPIC = "/binary"
+SESSION_EVENT = {
+    "meterData": {
+        "instantaneousPower": [3450, 3410, 3480],
+        "sessionEnergy": 13104,
+        "totalEnergy": 6529794,
+    },
+    "state": "charging",
+}
+
+
+async def peblar_ws_handler(request: web.Request) -> web.WebSocketResponse:
+    """Stand in for the charger's websocket, speaking its protocol."""
+    websocket = web.WebSocketResponse()
+    await websocket.prepare(request)
+
+    async for message in websocket:
+        if message.type is not WSMsgType.TEXT:
+            continue
+
+        payload = message.json()
+        action, topic = payload["action"], payload["topic"]
+
+        if topic == SILENT_TOPIC:
+            continue
+
+        if topic == REJECTED_TOPIC:
+            await websocket.send_json(
+                {
+                    "topic": topic,
+                    "type": "result",
+                    "data": {
+                        "action": action,
+                        "status": "error",
+                        "message": "Unknown topic",
+                    },
+                }
+            )
+            continue
+
+        await websocket.send_json(
+            {
+                "topic": topic,
+                "type": "result",
+                "data": {"action": action, "status": "ok", "message": "ok"},
+            }
+        )
+
+        if action == "subscribe" and topic == BINARY_TOPIC:
+            await websocket.send_bytes(b"not text")
+
+        # The real charger pushes current state right behind the ack.
+        if action == "subscribe" and topic == SESSION_TOPIC:
+            await websocket.send_json(
+                {"topic": topic, "type": "event", "data": SESSION_EVENT}
+            )
+        if action == "subscribe" and topic == WebsocketTopic.RFID_TOKEN_FOUND:
+            await websocket.send_json(
+                {
+                    "topic": topic,
+                    "type": "event",
+                    "data": {"tokenId": "0123456789ABCD"},
+                }
+            )
+
+    return websocket
+
+
+@pytest.fixture
+async def websocket() -> AsyncGenerator[PeblarWebsocket, None]:
+    """Return a PeblarWebsocket pointed at an in-process charger stand-in."""
+    app = web.Application()
+    app.router.add_get("/api/v1/ws", peblar_ws_handler)
+    server = TestServer(app)
+    await server.start_server()
+
+    async with ClientSession() as session:
+        client = PeblarWebsocket(host="example.com", session=session)
+        # The stand-in listens on an ephemeral port, so aim at it directly.
+        client.url = URL(f"ws://{server.host}:{server.port}/api/v1/ws")
+        yield client
+        await client.disconnect()
+
+    await server.close()
+
+
+async def test_connect_and_disconnect(websocket: PeblarWebsocket) -> None:
+    """Test the connection reports its own state."""
+    assert websocket.connected is False
+    await websocket.connect()
+    assert websocket.connected is True
+    await websocket.disconnect()
+    assert websocket.connected is False
+
+
+async def test_connect_is_idempotent(websocket: PeblarWebsocket) -> None:
+    """Test connecting twice keeps the existing connection."""
+    await websocket.connect()
+    client = websocket._client  # pylint: disable=protected-access
+    await websocket.connect()
+    assert websocket._client is client  # pylint: disable=protected-access
+
+
+async def test_subscribe_receives_initial_state(websocket: PeblarWebsocket) -> None:
+    """Test the state pushed right behind the ack is not dropped."""
+    received: list[PeblarSessionStatus] = []
+    arrived = asyncio.Event()
+
+    def collect(status: PeblarSessionStatus) -> None:
+        received.append(status)
+        arrived.set()
+
+    await websocket.connect()
+    await websocket.subscribe_session_status(collect)
+
+    async with asyncio.timeout(5):
+        await arrived.wait()
+
+    status = received[0]
+    assert status.state is SessionState.CHARGING
+    assert status.meter_data is not None
+    assert status.meter_data.session_energy == 13104
+    assert status.meter_data.instantaneous_power_total == 10340
+
+
+async def test_subscribe_token_found(websocket: PeblarWebsocket) -> None:
+    """Test RFID token events are parsed."""
+    received: list[PeblarTokenFound] = []
+    arrived = asyncio.Event()
+
+    def collect(token: PeblarTokenFound) -> None:
+        received.append(token)
+        arrived.set()
+
+    await websocket.connect()
+    await websocket.subscribe_token_found(collect)
+
+    async with asyncio.timeout(5):
+        await arrived.wait()
+
+    assert received[0].token_id == "0123456789ABCD"
+
+
+async def test_subscribe_raw_topic(websocket: PeblarWebsocket) -> None:
+    """Test a raw subscription hands the payload through untouched."""
+    await websocket.connect()
+    await websocket.subscribe(WebsocketTopic.STATUS_CHANGED, lambda _: None)
+    # pylint: disable-next=protected-access
+    assert WebsocketTopic.STATUS_CHANGED in websocket._callbacks
+
+
+async def test_subscribe_rejected(websocket: PeblarWebsocket) -> None:
+    """Test a topic the charger refuses raises and leaves no callback behind."""
+    await websocket.connect()
+    with pytest.raises(PeblarError, match="Unknown topic"):
+        await websocket.subscribe(REJECTED_TOPIC, lambda _: None)
+    # pylint: disable-next=protected-access
+    assert REJECTED_TOPIC not in websocket._callbacks
+
+
+async def test_unsubscribe_stops_callbacks(websocket: PeblarWebsocket) -> None:
+    """Test unsubscribing drops the callback."""
+    await websocket.connect()
+    await websocket.subscribe_session_status(lambda _: None)
+    await websocket.unsubscribe(SESSION_TOPIC)
+    # pylint: disable-next=protected-access
+    assert SESSION_TOPIC not in websocket._callbacks
+
+
+async def test_subscribe_without_connection(websocket: PeblarWebsocket) -> None:
+    """Test subscribing before connecting is refused."""
+    with pytest.raises(PeblarError, match="Not connected"):
+        await websocket.subscribe(SESSION_TOPIC, lambda _: None)
+
+
+async def test_listen_without_connection(websocket: PeblarWebsocket) -> None:
+    """Test listening before connecting is refused."""
+    with pytest.raises(PeblarError, match="Not connected"):
+        await websocket.listen()
+
+
+async def test_listen_returns_when_server_closes(
+    websocket: PeblarWebsocket,
+) -> None:
+    """Test listen returns once the charger hangs up."""
+    await websocket.connect()
+    await websocket.subscribe_session_status(lambda _: None)
+
+    client = websocket._client  # pylint: disable=protected-access
+    assert client is not None
+    await client.close()
+
+    async with asyncio.timeout(5):
+        await websocket.listen()
+
+    assert websocket.connected is False
+
+
+async def test_cancelling_listen_keeps_the_connection(
+    websocket: PeblarWebsocket,
+) -> None:
+    """Test listening is observing, not owning."""
+    await websocket.connect()
+    listener = asyncio.create_task(websocket.listen())
+    await asyncio.sleep(0)
+    listener.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await listener
+
+    assert websocket.connected is True
+    # The reader survived, so the charger still answers.
+    await websocket.subscribe_session_status(lambda _: None)
+
+
+async def test_connect_failure() -> None:
+    """Test an unreachable charger surfaces as a connection error."""
+    async with ClientSession() as session:
+        client = PeblarWebsocket(host="example.com", session=session)
+        # Port 1 on localhost has nothing listening.
+        client.url = URL("ws://127.0.0.1:1/api/v1/ws")
+        with pytest.raises(PeblarConnectionError, match="Error occurred"):
+            await client.connect()
+
+
+async def test_unknown_messages_are_ignored(websocket: PeblarWebsocket) -> None:
+    """Test malformed or unknown messages do not take the reader down."""
+    await websocket.connect()
+    # pylint: disable-next=protected-access
+    handle: Any = websocket._handle_message
+    handle({})
+    handle({"topic": "/unknown", "type": "event", "data": {}})
+    handle({"topic": SESSION_TOPIC, "type": "bogus", "data": {}})
+    assert websocket.connected is True
+
+
+async def test_subscribe_times_out(websocket: PeblarWebsocket) -> None:
+    """Test a charger that never acknowledges surfaces as a timeout."""
+    websocket.request_timeout = 0.1
+    await websocket.connect()
+    with pytest.raises(PeblarConnectionError, match="Timeout while trying"):
+        await websocket.subscribe(SILENT_TOPIC, lambda _: None)
+
+
+async def test_pending_subscribe_fails_when_connection_drops(
+    websocket: PeblarWebsocket,
+) -> None:
+    """Test an unanswered subscribe gives up when the charger hangs up."""
+    await websocket.connect()
+    pending = asyncio.create_task(websocket.subscribe(SILENT_TOPIC, lambda _: None))
+    await asyncio.sleep(0.05)
+
+    client = websocket._client  # pylint: disable=protected-access
+    assert client is not None
+    await client.close()
+
+    with pytest.raises(PeblarConnectionError, match="closed while waiting"):
+        await pending
+
+
+async def test_non_text_frames_are_skipped(websocket: PeblarWebsocket) -> None:
+    """Test a binary frame does not take the reader down."""
+    await websocket.connect()
+    await websocket.subscribe(BINARY_TOPIC, lambda _: None)
+    await asyncio.sleep(0.05)
+    assert websocket.connected is True
+
+
+async def test_send_failure_surfaces_as_connection_error(
+    websocket: PeblarWebsocket,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test a failing send is reported as a connection error."""
+    await websocket.connect()
+
+    async def boom(*_args: Any, **_kwargs: Any) -> None:
+        raise ClientError
+
+    # pylint: disable-next=protected-access
+    monkeypatch.setattr(websocket._client, "send_json", boom)
+    with pytest.raises(PeblarConnectionError, match="Error occurred while trying"):
+        await websocket.subscribe(SESSION_TOPIC, lambda _: None)
+
+
+async def test_async_context_manager(websocket: PeblarWebsocket) -> None:
+    """Test the websocket connects and disconnects as a context manager."""
+    async with websocket as connected:
+        assert connected.connected is True
+    assert websocket.connected is False

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -12,7 +13,11 @@ from aiohttp.test_utils import TestServer
 from yarl import URL
 
 from peblar.const import SessionState, WebsocketTopic
-from peblar.exceptions import PeblarConnectionError, PeblarError
+from peblar.exceptions import (
+    PeblarConnectionError,
+    PeblarConnectionTimeoutError,
+    PeblarError,
+)
 from peblar.websocket import PeblarWebsocket, session_status_topic
 
 if TYPE_CHECKING:
@@ -272,7 +277,9 @@ async def test_subscribe_times_out(websocket: PeblarWebsocket) -> None:
     """Test a charger that never acknowledges surfaces as a timeout."""
     websocket.request_timeout = 0.1
     await websocket.connect()
-    with pytest.raises(PeblarConnectionError, match="Timeout on the subscribe request"):
+    with pytest.raises(
+        PeblarConnectionTimeoutError, match="Timeout on the subscribe request"
+    ):
         await websocket.subscribe(SILENT_TOPIC, lambda _: None)
 
 
@@ -512,3 +519,31 @@ async def test_a_failing_close_does_not_mask_the_real_error(
 
     # And teardown still does not raise.
     await websocket.disconnect()
+
+
+async def test_disconnect_clears_in_flight_bookkeeping(
+    websocket: PeblarWebsocket,
+) -> None:
+    """Test a reconnect is not blocked by the previous connection.
+
+    The in-flight guard rejects a second request for a topic, so a
+    disconnect during an unanswered request has to drop that bookkeeping
+    or the first request after reconnecting is refused on behalf of a
+    connection that no longer exists.
+    """
+    await websocket.connect()
+
+    pending = asyncio.create_task(websocket.subscribe(SILENT_TOPIC, lambda _: None))
+    await asyncio.sleep(0.05)
+    assert websocket._pending  # pylint: disable=protected-access
+
+    await websocket.disconnect()
+    pending.cancel()
+    with contextlib.suppress(asyncio.CancelledError, PeblarError):
+        await pending
+
+    assert not websocket._pending  # pylint: disable=protected-access
+
+    # Reconnecting and asking for the same topic again is fine.
+    await websocket.connect()
+    await websocket.subscribe_session_status(lambda _: None)

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -468,3 +468,47 @@ async def test_cancelling_listen_leaves_the_socket_open(
     assert client is not None
     assert client.closed is False
     assert websocket.connected is True
+
+
+async def test_connect_to_a_closed_session(websocket: PeblarWebsocket) -> None:
+    """Test a closed session surfaces as a connection error.
+
+    aiohttp raises RuntimeError there rather than a ClientError, so it
+    used to escape as an unexpected exception type.
+    """
+    await websocket.session.close()
+    with pytest.raises(PeblarConnectionError, match="Error occurred"):
+        await websocket.connect()
+
+
+async def test_a_failing_close_does_not_mask_the_real_error(
+    websocket: PeblarWebsocket,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test a broken close cannot replace what actually stopped the reader.
+
+    listen() reports the cause, so a teardown failure must not overwrite
+    it on the way out.
+    """
+    await websocket.connect()
+
+    async def failing_close(*_args: Any, **_kwargs: Any) -> None:
+        msg = "close blew up"
+        raise RuntimeError(msg)
+
+    def boom(_data: dict[str, Any]) -> None:
+        msg = "consumer bug"
+        raise RuntimeError(msg)
+
+    client = websocket._client  # pylint: disable=protected-access
+    assert client is not None
+    monkeypatch.setattr(client, "close", failing_close)
+
+    await websocket.subscribe_session_status(lambda _: boom({}))
+
+    # The consumer bug, not the close failure.
+    with pytest.raises(RuntimeError, match="consumer bug"):
+        await websocket.listen()
+
+    # And teardown still does not raise.
+    await websocket.disconnect()

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -1,5 +1,6 @@
 """Tests for `peblar.websocket`."""
 
+# pylint: disable=redefined-outer-name
 from __future__ import annotations
 
 import asyncio
@@ -23,6 +24,7 @@ SESSION_TOPIC = session_status_topic()
 REJECTED_TOPIC = "/nope"
 SILENT_TOPIC = "/silent"
 BINARY_TOPIC = "/binary"
+GARBAGE_TOPIC = "/garbage"
 SESSION_EVENT = {
     "meterData": {
         "instantaneousPower": [3450, 3410, 3480],
@@ -72,6 +74,15 @@ async def peblar_ws_handler(request: web.Request) -> web.WebSocketResponse:
 
         if action == "subscribe" and topic == BINARY_TOPIC:
             await websocket.send_bytes(b"not text")
+
+        if action == "subscribe" and topic == GARBAGE_TOPIC:
+            # Not JSON at all, then valid JSON that is not an object, then
+            # a well formed message whose data is null.
+            await websocket.send_str("}{ not json")
+            await websocket.send_str("[1, 2, 3]")
+            await websocket.send_json(
+                {"topic": GARBAGE_TOPIC, "type": "event", "data": None}
+            )
 
         # The real charger pushes current state right behind the ack.
         if action == "subscribe" and topic == SESSION_TOPIC:
@@ -310,3 +321,46 @@ async def test_async_context_manager(websocket: PeblarWebsocket) -> None:
     async with websocket as connected:
         assert connected.connected is True
     assert websocket.connected is False
+
+
+async def test_malformed_frames_do_not_kill_the_reader(
+    websocket: PeblarWebsocket,
+) -> None:
+    """Test junk on the wire is skipped rather than ending every subscription.
+
+    The reader task serves every subscription on the connection, so an
+    exception in it would silently stop all of them.
+    """
+    received: list[dict[str, Any]] = []
+    await websocket.connect()
+    await websocket.subscribe(GARBAGE_TOPIC, received.append)
+    await asyncio.sleep(0.05)
+
+    # Still alive, and the null data arrived normalised to an empty dict.
+    assert websocket.connected is True
+    assert received == [{}]
+
+    # And the connection still works afterwards.
+    await websocket.subscribe_session_status(lambda _: None)
+
+
+async def test_one_in_flight_request_per_topic(
+    websocket: PeblarWebsocket,
+) -> None:
+    """Test a second request for a topic cannot orphan the first one.
+
+    Both used to write into the same pending slot, so one caller would
+    wait forever for a result that had already been handed to the other.
+    """
+    await websocket.connect()
+    websocket.request_timeout = 5
+
+    first = asyncio.create_task(websocket.subscribe(SILENT_TOPIC, lambda _: None))
+    await asyncio.sleep(0.05)
+
+    with pytest.raises(PeblarError, match="already in flight"):
+        await websocket.subscribe(SILENT_TOPIC, lambda _: None)
+
+    first.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await first

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -364,3 +364,61 @@ async def test_one_in_flight_request_per_topic(
     first.cancel()
     with pytest.raises(asyncio.CancelledError):
         await first
+
+
+async def test_a_raising_callback_is_visible_not_silent(
+    websocket: PeblarWebsocket,
+) -> None:
+    """Test a callback that raises does not leave a zombie connection.
+
+    One reader serves every subscription, so a raising callback stops
+    them all. That has to be observable rather than leaving `connected`
+    claiming everything is fine.
+    """
+    await websocket.connect()
+
+    def boom(_data: dict[str, Any]) -> None:
+        msg = "consumer bug"
+        raise RuntimeError(msg)
+
+    await websocket.subscribe_session_status(lambda _: boom({}))
+    await asyncio.sleep(0.05)
+
+    assert websocket.connected is False
+    with pytest.raises(RuntimeError, match="consumer bug"):
+        await websocket.listen()
+
+
+async def test_disconnect_never_raises(websocket: PeblarWebsocket) -> None:
+    """Test teardown stays safe even when the reader died of something.
+
+    disconnect() gets called from `finally` blocks and context manager
+    exits, so it must not resurrect whatever killed the reader.
+    """
+    await websocket.connect()
+
+    def boom(_data: dict[str, Any]) -> None:
+        msg = "consumer bug"
+        raise RuntimeError(msg)
+
+    await websocket.subscribe_session_status(lambda _: boom({}))
+    await asyncio.sleep(0.05)
+
+    await websocket.disconnect()
+    assert websocket.connected is False
+
+
+async def test_context_manager_exit_survives_a_dead_reader(
+    websocket: PeblarWebsocket,
+) -> None:
+    """Test `async with` unwinds cleanly after a callback blew up."""
+
+    def boom(_data: dict[str, Any]) -> None:
+        msg = "consumer bug"
+        raise RuntimeError(msg)
+
+    async with websocket as connected:
+        await connected.subscribe_session_status(lambda _: boom({}))
+        await asyncio.sleep(0.05)
+
+    assert websocket.connected is False


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

The charger runs an undocumented pub/sub websocket at `/api/v1/ws`, authenticated with the same session cookie as the web API. Subscribing to a topic gets you the current state immediately and then every change as it happens, which is a better fit than polling and sidesteps the documented five requests per second limit entirely.

`PeblarWebsocket` handles the connection, subscriptions and dispatch. `subscribe_session_status()` gives typed events carrying per phase power, session energy, lifetime energy and a session state. `subscribe_token_found()` covers RFID and vehicle tokens being presented. Raw `subscribe()` is there for topics without a typed helper, such as the diagnostics status feed.

`SessionState` covers the seven values the charger's own web interface knows how to render. Two of them, `preparingAuthorized` and `preparingPluggedIn`, distinguish waiting for a cable from waiting for authorization, which the CP state cannot express.

Testing this against a real charger turned up two bugs that a mocked transport would never have shown:

The charger sends the subscribe acknowledgement and the current state back to back. Registering the callback after awaiting the ack meant the first event arrived with nothing listening, so an idle charger could go hours before a consumer saw any state at all. The callback is now registered before the subscribe is sent.

Cancelling `listen()` used to tear down the connection, because it awaited the reader task directly and cancellation propagated into it, leaving `connected` reporting True while nothing was being processed. It now shields the reader: listening observes, `disconnect()` owns.

Both have regression tests. The suite runs a real in-process aiohttp websocket server speaking the charger's protocol rather than stubbing the transport, which is what made those two findable in the first place.

Also adds `peblar watch`, which streams session updates until interrupted.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
