### PR TITLE
Add firmware update progress and cache control

### DIFF
--- a/src/peblar/__init__.py
+++ b/src/peblar/__init__.py
@@ -2,6 +2,7 @@
 
 from .const import (
     MINIMUM_FIRMWARE_VERSION_LOCAL_REST_API,
+    PACKAGE_UPDATE_ORDER,
     AccessMode,
     AuthorizationMethod,
     ChargeLimiter,
@@ -30,6 +31,7 @@ from .models import (
     PeblarEnergyHistoryMonth,
     PeblarEnergyHistoryYear,
     PeblarEVInterface,
+    PeblarFirmwareUpdateStatus,
     PeblarHealth,
     PeblarMeter,
     PeblarRfidToken,
@@ -52,6 +54,7 @@ from .websocket import PeblarWebsocket, session_status_topic
 
 __all__ = [
     "MINIMUM_FIRMWARE_VERSION_LOCAL_REST_API",
+    "PACKAGE_UPDATE_ORDER",
     "AccessMode",
     "AuthorizationMethod",
     "CPState",
@@ -71,6 +74,7 @@ __all__ = [
     "PeblarEnergyHistoryMonth",
     "PeblarEnergyHistoryYear",
     "PeblarError",
+    "PeblarFirmwareUpdateStatus",
     "PeblarHealth",
     "PeblarMeter",
     "PeblarResponseError",

--- a/src/peblar/const.py
+++ b/src/peblar/const.py
@@ -139,6 +139,9 @@ class WebsocketTopic(StrEnum):
     PeblarWebsocket.subscribe_session_status().
     """
 
+    FIRMWARE_UPDATE_STATUS = "/system/fwupdate/status"
+    """Progress of a running firmware update."""
+
     RFID_TOKEN_FOUND = "/rfid/tokenfound"  # noqa: S105
     """An RFID token was held against the reader."""
 
@@ -246,3 +249,9 @@ class PackageType(StrEnum):
 
     CUSTOMIZATION = "Customization"
     """Customization package."""
+
+
+# Order the charger expects its packages to be updated in. The web
+# interface always sends Customization first, then Firmware, waiting for
+# the charger to reboot in between.
+PACKAGE_UPDATE_ORDER = (PackageType.CUSTOMIZATION, PackageType.FIRMWARE)

--- a/src/peblar/models.py
+++ b/src/peblar/models.py
@@ -1036,6 +1036,25 @@ class PeblarSessionStatus(BaseModel):
 
 
 @dataclass(kw_only=True)
+class PeblarFirmwareUpdateStatus(BaseModel):
+    """Object holding the progress of a running firmware update.
+
+    Pushed over the websocket while the charger updates itself. The
+    charger hangs on to the result of the last update, so subscribing
+    also tells you how the previous one went.
+
+    Peblar does not document the status values. `EFwUpdateSuccess` is one
+    observed in the wild; the charger's web interface only ever falls
+    back to "Unknown" of its own accord. That is too thin a basis for an
+    enum, so this stays a plain string.
+    """
+
+    status: str = field(metadata=field_options(alias="status"))
+    firmware_old: str = field(default="", metadata=field_options(alias="fwIdentOld"))
+    firmware_new: str = field(default="", metadata=field_options(alias="fwIdentNew"))
+
+
+@dataclass(kw_only=True)
 class PeblarTokenFound(BaseModel):
     """Object holding an RFID or vehicle token event."""
 

--- a/src/peblar/models.py
+++ b/src/peblar/models.py
@@ -1044,7 +1044,7 @@ class PeblarFirmwareUpdateStatus(BaseModel):
     also tells you how the previous one went.
 
     Peblar does not document the status values. `EFwUpdateSuccess` is one
-    observed in the wild; the charger's web interface only ever falls
+    value observed in the wild; the charger's web interface only ever falls
     back to "Unknown" of its own accord. That is too thin a basis for an
     enum, so this stays a plain string.
     """

--- a/src/peblar/peblar.py
+++ b/src/peblar/peblar.py
@@ -309,10 +309,17 @@ class Peblar:
         result = await self.request(url)
         return PeblarApiToken.from_json(result).api_token
 
-    async def available_versions(self) -> PeblarVersions:
-        """Get available versions."""
+    async def available_versions(self, *, use_cache: bool = True) -> PeblarVersions:
+        """Get available versions.
+
+        The charger caches what it last heard from Peblar's update
+        servers. Pass use_cache=False to make it go and ask again, which
+        is what you want while waiting for an update to land.
+        """
         result = await self.request(
-            URL("system/software/automatic-update/available-versions")
+            URL("system/software/automatic-update/available-versions").with_query(
+                {"UseCache": "true" if use_cache else "false"}
+            )
         )
         return PeblarVersions.from_json(result)
 
@@ -477,7 +484,14 @@ class Peblar:
         )
 
     async def update(self, *, package_type: PackageType) -> None:
-        """Update the Peblar charger to the latest version."""
+        """Update the Peblar charger to the latest version.
+
+        One package at a time, in PACKAGE_UPDATE_ORDER: the charger wants
+        Customization before Firmware. It reboots on its own afterwards,
+        so this returns long before the update is done. Subscribe to
+        PeblarWebsocket.subscribe_firmware_update_status() first to
+        follow along.
+        """
         await self.request(
             URL("system/software/automatic-update/update"),
             method=hdrs.METH_POST,

--- a/src/peblar/websocket.py
+++ b/src/peblar/websocket.py
@@ -17,7 +17,11 @@ from .exceptions import (
     PeblarConnectionTimeoutError,
     PeblarError,
 )
-from .models import PeblarSessionStatus, PeblarTokenFound
+from .models import (
+    PeblarFirmwareUpdateStatus,
+    PeblarSessionStatus,
+    PeblarTokenFound,
+)
 
 if TYPE_CHECKING:
     from aiohttp import ClientSession, ClientWebSocketResponse
@@ -123,6 +127,21 @@ class PeblarWebsocket:
         await self.subscribe(
             session_status_topic(connector),
             lambda data: callback(PeblarSessionStatus.from_dict(data)),
+        )
+
+    async def subscribe_firmware_update_status(
+        self,
+        callback: Callable[[PeblarFirmwareUpdateStatus], None],
+    ) -> None:
+        """Subscribe to the progress of a running firmware update.
+
+        Subscribe before triggering the update, otherwise you miss the
+        early steps. The charger also replays the result of the previous
+        update on subscribe.
+        """
+        await self.subscribe(
+            WebsocketTopic.FIRMWARE_UPDATE_STATUS,
+            lambda data: callback(PeblarFirmwareUpdateStatus.from_dict(data)),
         )
 
     async def subscribe_token_found(

--- a/tests/test_peblar.py
+++ b/tests/test_peblar.py
@@ -12,6 +12,7 @@ from yarl import URL
 
 from peblar import Peblar
 from peblar.const import (
+    PACKAGE_UPDATE_ORDER,
     AccessMode,
     ChargeLimiter,
     CPState,
@@ -59,6 +60,8 @@ CURRENT_VERSIONS_URL = BASE_URL + "system/software/automatic-update/current-vers
 AVAILABLE_VERSIONS_URL = (
     BASE_URL + "system/software/automatic-update/available-versions"
 )
+AVAILABLE_VERSIONS_CACHED_URL = AVAILABLE_VERSIONS_URL + "?UseCache=true"
+AVAILABLE_VERSIONS_FRESH_URL = AVAILABLE_VERSIONS_URL + "?UseCache=false"
 API_TOKEN_URL = BASE_URL + "config/api-token"
 REBOOT_URL = BASE_URL + "system/reboot"
 UPDATE_URL = BASE_URL + "system/software/automatic-update/update"
@@ -350,7 +353,7 @@ async def test_available_versions() -> None:
     """Test available_versions parses the versions payload."""
     with aioresponses() as mocked:
         mocked.get(
-            AVAILABLE_VERSIONS_URL,
+            AVAILABLE_VERSIONS_CACHED_URL,
             status=200,
             body=load_fixture("versions_available.json"),
         )
@@ -1865,3 +1868,28 @@ async def test_websocket_shares_the_logged_in_session() -> None:
             websocket = peblar.websocket()
     assert websocket.session is peblar.session
     assert websocket.url == URL(f"ws://{HOST}/api/v1/ws")
+
+
+async def test_available_versions_uncached() -> None:
+    """Test asking the charger to go and re-check for updates.
+
+    The charger serves a cached answer by default, which is not what you
+    want while waiting for an update to appear.
+    """
+    with aioresponses() as mocked:
+        mocked.get(
+            AVAILABLE_VERSIONS_FRESH_URL,
+            status=200,
+            body=load_fixture("versions_available.json"),
+        )
+        async with Peblar(host=HOST) as peblar:
+            versions = await peblar.available_versions(use_cache=False)
+    assert versions.firmware is not None
+
+
+def test_package_update_order() -> None:
+    """Test the documented order the charger expects its packages in."""
+    assert [package.value for package in PACKAGE_UPDATE_ORDER] == [
+        "Customization",
+        "Firmware",
+    ]

--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -18,6 +18,7 @@ from peblar.exceptions import (
     PeblarConnectionTimeoutError,
     PeblarError,
 )
+from peblar.models import PeblarFirmwareUpdateStatus
 from peblar.websocket import PeblarWebsocket, session_status_topic
 
 if TYPE_CHECKING:
@@ -93,6 +94,18 @@ async def peblar_ws_handler(request: web.Request) -> web.WebSocketResponse:
         if action == "subscribe" and topic == SESSION_TOPIC:
             await websocket.send_json(
                 {"topic": topic, "type": "event", "data": SESSION_EVENT}
+            )
+        if action == "subscribe" and topic == WebsocketTopic.FIRMWARE_UPDATE_STATUS:
+            await websocket.send_json(
+                {
+                    "topic": topic,
+                    "type": "event",
+                    "data": {
+                        "status": "EFwUpdateSuccess",
+                        "fwIdentOld": "1.9.1+1+WL-1",
+                        "fwIdentNew": "1.9.2+1+WL-1",
+                    },
+                }
             )
         if action == "subscribe" and topic == WebsocketTopic.RFID_TOKEN_FOUND:
             await websocket.send_json(
@@ -580,3 +593,34 @@ async def test_cancelling_listen_still_cancels_the_caller(
 
     # The connection is untouched, listening is only observing.
     assert websocket.connected is True
+
+
+async def test_subscribe_firmware_update_status(websocket: PeblarWebsocket) -> None:
+    """Test firmware update progress events are parsed.
+
+    The charger replays the result of the last update on subscribe, so
+    this arrives without an update having been triggered.
+    """
+    received: list[PeblarFirmwareUpdateStatus] = []
+    arrived = asyncio.Event()
+
+    def collect(status: PeblarFirmwareUpdateStatus) -> None:
+        received.append(status)
+        arrived.set()
+
+    await websocket.connect()
+    await websocket.subscribe_firmware_update_status(collect)
+
+    async with asyncio.timeout(5):
+        await arrived.wait()
+
+    assert received[0].status == "EFwUpdateSuccess"
+    assert received[0].firmware_old == "1.9.1+1+WL-1"
+    assert received[0].firmware_new == "1.9.2+1+WL-1"
+
+
+def test_firmware_update_status_version_fields_are_optional() -> None:
+    """Test a status without version identifiers still parses."""
+    status = PeblarFirmwareUpdateStatus.from_dict({"status": "Unknown"})
+    assert status.firmware_old == ""
+    assert status.firmware_new == ""


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

The charger pushes firmware update progress on a `/system/fwupdate/status` websocket topic, carrying a status along with the old and new firmware identifiers. It also hangs on to the result of the last update, so subscribing tells you how the previous one went before anything has happened. Subscribing on a charger that last updated from 1.9.0 to 1.9.1 replays that immediately.

`available_versions()` gains `use_cache`. The charger serves what it last heard from Peblar's update servers, and the web interface passes this explicitly to force a re-check, which is what you want while waiting for an update to appear.

`PACKAGE_UPDATE_ORDER` records something the API does not tell you: the web interface always updates Customization before Firmware, waiting for the charger to reboot in between. `update()` now says out loud that it returns long before the update is finished.

Two deliberate choices worth stating.

The status stays a plain string rather than an enum. `EFwUpdateSuccess` is the only value observed on a real charger, and the web interface only ever falls back to "Unknown" of its own accord. That is not enough to build an enum that would raise on the first value Peblar adds.

There is no reboot waiting orchestrator here. The web interface implements one, waiting for the backend to drop and come back with its own timeouts, but none of that can be tested without running a real firmware update. An untested state machine wrapped around firmware flashing is worse than no state machine, so this provides the pieces and leaves the sequencing to the caller.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Builds on #445, which added the websocket client.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
