### PR TITLE
Anonymize RFID tokens in dumps

### DIFF
--- a/src/peblar/cli/__init__.py
+++ b/src/peblar/cli/__init__.py
@@ -2516,19 +2516,29 @@ _JSON_PARAM_KEYS = frozenset(
 )
 
 
-def _anonymize_tokens(tokens: Sequence[object]) -> list[dict[str, str]]:
-    """Replace RFID tokens with sequential stand-ins.
+def _anonymize_tokens(tokens: Sequence[object]) -> list[object]:
+    """Replace the identifying parts of each RFID token.
 
     A token UID identifies a physical card someone carries around, so it
-    has no business ending up in a fixture file or a bug report.
+    has no business ending up in a fixture file or a bug report. Only
+    those parts are replaced: any other field is kept, so a token the
+    firmware grows later still shows up in the dump.
+
+    An entry that is not a token object is redacted outright, since there
+    is no way to tell whether it carries an identifier.
     """
-    return [
-        {
-            "RfidTokenUid": f"{index:014X}",
-            "RfidTokenDescription": f"RFID card {index}",
-        }
-        for index in range(1, len(tokens) + 1)
-    ]
+    anonymized: list[object] = []
+    for index, token in enumerate(tokens, start=1):
+        if not isinstance(token, dict):
+            anonymized.append("<redacted>")
+            continue
+
+        entry: dict[str, object] = {str(key): value for key, value in token.items()}
+        entry["RfidTokenUid"] = f"{index:014X}"
+        entry["RfidTokenDescription"] = f"RFID card {index}"
+        anonymized.append(entry)
+
+    return anonymized
 
 
 def _anonymize(data: dict[str, object]) -> dict[str, object]:

--- a/src/peblar/cli/__init__.py
+++ b/src/peblar/cli/__init__.py
@@ -2551,8 +2551,15 @@ def _anonymize(data: dict[str, object]) -> dict[str, object]:
     result: dict[str, object] = {}
 
     for key, original in data.items():
-        if key == "Tokens" and isinstance(original, list):
-            result[key] = _anonymize_tokens(original)
+        if key == "Tokens":
+            # Anything that is not a list of tokens cannot be scrubbed
+            # field by field, and this is a privacy boundary rather than
+            # a best effort, so it does not get the benefit of the doubt.
+            result[key] = (
+                _anonymize_tokens(original)
+                if isinstance(original, list)
+                else "<redacted>"
+            )
         elif key in _REDACT_MAP:
             result[key] = _REDACT_MAP[key]
         elif key in _MAC_KEYS:

--- a/src/peblar/cli/__init__.py
+++ b/src/peblar/cli/__init__.py
@@ -8,6 +8,7 @@ import json
 import locale
 import sys
 from collections import defaultdict
+from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -2515,6 +2516,21 @@ _JSON_PARAM_KEYS = frozenset(
 )
 
 
+def _anonymize_tokens(tokens: Sequence[object]) -> list[dict[str, str]]:
+    """Replace RFID tokens with sequential stand-ins.
+
+    A token UID identifies a physical card someone carries around, so it
+    has no business ending up in a fixture file or a bug report.
+    """
+    return [
+        {
+            "RfidTokenUid": f"{index:014X}",
+            "RfidTokenDescription": f"RFID card {index}",
+        }
+        for index in range(1, len(tokens) + 1)
+    ]
+
+
 def _anonymize(data: dict[str, object]) -> dict[str, object]:
     """Strip personally identifiable or device-unique fields from a response.
 
@@ -2525,7 +2541,9 @@ def _anonymize(data: dict[str, object]) -> dict[str, object]:
     result: dict[str, object] = {}
 
     for key, original in data.items():
-        if key in _REDACT_MAP:
+        if key == "Tokens" and isinstance(original, list):
+            result[key] = _anonymize_tokens(original)
+        elif key in _REDACT_MAP:
             result[key] = _REDACT_MAP[key]
         elif key in _MAC_KEYS:
             mac_counter += 1
@@ -2647,6 +2665,10 @@ async def dump(  # noqa: PLR0913
             "api_token.json",
             await peblar.request(URL("config/api-token")),
         )
+        _write(
+            "standalonelist.json",
+            await peblar.request(URL("config/auth/standalonelist")),
+        )
 
         # Local REST API endpoints (only available when enabled)
         if not quiet:
@@ -2660,6 +2682,9 @@ async def dump(  # noqa: PLR0913
         except PeblarConnectionError:
             if not quiet:
                 console.print("  [yellow]Skipped (could not connect to REST API)")
+        except PeblarUnsupportedFirmwareVersionError:
+            if not quiet:
+                console.print("  [yellow]Skipped (firmware too old for the REST API)")
         except PeblarError:
             if not quiet:
                 console.print(

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -582,3 +582,42 @@ def test_anonymize_empty_token_list() -> None:
 def test_anonymize_leaves_unknown_keys_alone() -> None:
     """Keys the anonymizer knows nothing about are passed through."""
     assert _anonymize({"SomethingNew": 42}) == {"SomethingNew": 42}
+
+
+def test_anonymize_tokens_keeps_fields_it_does_not_know() -> None:
+    """Fields newer firmware adds to a token survive the anonymizer.
+
+    The point of a dump is to be a useful fixture, so only the parts that
+    identify a physical card get replaced.
+    """
+    anonymized = _anonymize(
+        {
+            "Tokens": [
+                {
+                    "RfidTokenUid": "0123456789ABCD",
+                    "RfidTokenDescription": "My RFID Card",
+                    "ValidUntil": "2027-01-01",
+                    "Blocked": False,
+                }
+            ]
+        }
+    )
+    assert anonymized == {
+        "Tokens": [
+            {
+                "RfidTokenUid": "00000000000001",
+                "RfidTokenDescription": "RFID card 1",
+                "ValidUntil": "2027-01-01",
+                "Blocked": False,
+            }
+        ]
+    }
+
+
+def test_anonymize_tokens_redacts_anything_that_is_not_a_token() -> None:
+    """An entry that is not an object cannot be scrubbed, so it goes.
+
+    There is no way to tell whether a bare value carries an identifier,
+    and a dump is the wrong place to gamble on that.
+    """
+    assert _anonymize({"Tokens": ["0123456789ABCD"]}) == {"Tokens": ["<redacted>"]}

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -12,7 +12,7 @@ import pytest
 from typer.main import get_command
 from typer.testing import CliRunner
 
-from peblar.cli import cli, convert_to_string
+from peblar.cli import _anonymize, cli, convert_to_string
 from peblar.exceptions import (
     PeblarAuthenticationError,
     PeblarBadRequestError,
@@ -544,3 +544,41 @@ def test_history(runner: CliRunner, snapshot: SnapshotAssertion) -> None:
     exit_code, output = _invoke(runner, ["history", *_AUTH], mock_cls)
     assert exit_code == 0
     assert output == snapshot
+
+
+# ---------------------------------------------------------------------------
+# Dump anonymization
+# ---------------------------------------------------------------------------
+
+
+def test_anonymize_rfid_tokens() -> None:
+    """RFID token UIDs are replaced with sequential stand-ins.
+
+    A UID identifies a physical card, so it must not survive into a
+    fixture file or a bug report.
+    """
+    data = orjson.loads(load_fixture("standalonelist.json"))
+    original_uids = {token["RfidTokenUid"] for token in data["Tokens"]}
+
+    anonymized = _anonymize(data)
+
+    assert anonymized == {
+        "Tokens": [
+            {"RfidTokenUid": "00000000000001", "RfidTokenDescription": "RFID card 1"},
+            {"RfidTokenUid": "00000000000002", "RfidTokenDescription": "RFID card 2"},
+        ]
+    }
+    # Nothing of the real card survived.
+    rendered = orjson.dumps(anonymized).decode()
+    assert not any(uid in rendered for uid in original_uids)
+    assert "My RFID Card" not in rendered
+
+
+def test_anonymize_empty_token_list() -> None:
+    """A charger with no tokens registered still anonymizes cleanly."""
+    assert _anonymize({"Tokens": []}) == {"Tokens": []}
+
+
+def test_anonymize_leaves_unknown_keys_alone() -> None:
+    """Keys the anonymizer knows nothing about are passed through."""
+    assert _anonymize({"SomethingNew": 42}) == {"SomethingNew": 42}

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -16,6 +16,7 @@ from peblar.cli import _anonymize, cli, convert_to_string
 from peblar.exceptions import (
     PeblarAuthenticationError,
     PeblarBadRequestError,
+    PeblarError,
     PeblarRateLimitError,
     PeblarUnsupportedFirmwareVersionError,
 )
@@ -33,6 +34,8 @@ from peblar.models import (
 from tests import load_fixture
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from syrupy.assertion import SnapshotAssertion
 
 
@@ -621,3 +624,104 @@ def test_anonymize_tokens_redacts_anything_that_is_not_a_token() -> None:
     and a dump is the wrong place to gamble on that.
     """
     assert _anonymize({"Tokens": ["0123456789ABCD"]}) == {"Tokens": ["<redacted>"]}
+
+
+# ---------------------------------------------------------------------------
+# Dump command
+# ---------------------------------------------------------------------------
+
+_DUMP_RESPONSES = {
+    "system/info": "system_information.json",
+    "config/user": "user_configuration.json",
+    "system/software/automatic-update/current-versions": "versions_current.json",
+    "system/software/automatic-update/available-versions": "versions_available.json",
+    "config/api-token": "api_token.json",
+    "config/auth/standalonelist": "standalonelist.json",
+}
+
+
+def _mock_peblar_for_dump(rest_api_error: Exception | None = None) -> MagicMock:
+    """Mock a Peblar whose raw request() serves the web API fixtures."""
+
+    async def fake_request(uri: object, **_kwargs: object) -> str:
+        return load_fixture(_DUMP_RESPONSES[str(uri)])
+
+    client = AsyncMock()
+    client.login.return_value = None
+    client.request.side_effect = fake_request
+    client.rest_api.side_effect = rest_api_error or PeblarError("not enabled")
+
+    instance = AsyncMock()
+    instance.__aenter__.return_value = client
+    instance.__aexit__.return_value = None
+    return MagicMock(return_value=instance)
+
+
+def test_dump_writes_an_anonymized_standalone_list(
+    runner: CliRunner,
+    tmp_path: Path,
+) -> None:
+    """Dump captures the auth list with the card identifiers scrubbed.
+
+    The whole point of the command is producing something safe to paste
+    into a bug report, so the real UIDs must not reach the file.
+    """
+    mock_cls = _mock_peblar_for_dump()
+    exit_code, _ = _invoke(
+        runner, ["dump", *_AUTH, "--output", str(tmp_path)], mock_cls
+    )
+    assert exit_code == 0
+
+    written = tmp_path / "standalonelist.json"
+    assert written.exists()
+
+    dumped = orjson.loads(written.read_bytes())
+    assert dumped == {
+        "Tokens": [
+            {"RfidTokenUid": "00000000000001", "RfidTokenDescription": "RFID card 1"},
+            {"RfidTokenUid": "00000000000002", "RfidTokenDescription": "RFID card 2"},
+        ]
+    }
+
+    original = orjson.loads(load_fixture("standalonelist.json"))
+    raw = written.read_text()
+    assert all(token["RfidTokenUid"] not in raw for token in original["Tokens"])
+
+
+def test_dump_raw_keeps_the_real_tokens(runner: CliRunner, tmp_path: Path) -> None:
+    """The --raw escape hatch still writes what the charger actually sent."""
+    mock_cls = _mock_peblar_for_dump()
+    exit_code, _ = _invoke(
+        runner, ["dump", *_AUTH, "--output", str(tmp_path), "--raw"], mock_cls
+    )
+    assert exit_code == 0
+
+    dumped = orjson.loads((tmp_path / "standalonelist.json").read_bytes())
+    assert dumped == orjson.loads(load_fixture("standalonelist.json"))
+
+
+def test_dump_reports_firmware_too_old(runner: CliRunner, tmp_path: Path) -> None:
+    """Old firmware is diagnosed as old, not as a disabled REST API."""
+    mock_cls = _mock_peblar_for_dump(
+        rest_api_error=PeblarUnsupportedFirmwareVersionError("requires firmware 1.6")
+    )
+    exit_code, output = _invoke(
+        runner, ["dump", *_AUTH, "--output", str(tmp_path)], mock_cls
+    )
+    assert exit_code == 0
+    assert "firmware too old" in output
+    assert "not enabled" not in output
+
+    # The web API fixtures still landed; only the REST ones were skipped.
+    assert (tmp_path / "standalonelist.json").exists()
+    assert not (tmp_path / "meter.json").exists()
+
+
+def test_dump_reports_a_disabled_rest_api(runner: CliRunner, tmp_path: Path) -> None:
+    """A charger with the API switched off still says so."""
+    mock_cls = _mock_peblar_for_dump()
+    exit_code, output = _invoke(
+        runner, ["dump", *_AUTH, "--output", str(tmp_path)], mock_cls
+    )
+    assert exit_code == 0
+    assert "not enabled or not allowed" in output

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -626,6 +626,19 @@ def test_anonymize_tokens_redacts_anything_that_is_not_a_token() -> None:
     assert _anonymize({"Tokens": ["0123456789ABCD"]}) == {"Tokens": ["<redacted>"]}
 
 
+@pytest.mark.parametrize(
+    "tokens",
+    ["0123456789ABCD", {"RfidTokenUid": "0123456789ABCD"}, 42, None],
+)
+def test_anonymize_redacts_a_token_list_that_is_not_a_list(tokens: object) -> None:
+    """A Tokens value of the wrong shape cannot be scrubbed, so it goes.
+
+    Walking the fields only works on a list of token objects. Anything
+    else is redacted whole, rather than trusted to be harmless.
+    """
+    assert _anonymize({"Tokens": tokens}) == {"Tokens": "<redacted>"}
+
+
 # ---------------------------------------------------------------------------
 # Dump command
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

`peblar dump` exists to capture real charger responses as fixtures, which is why it already scrubs serial numbers, MAC addresses, API tokens and public keys before writing anything out. It was not capturing the standalone auth list at all, and the test suite has a `standalonelist.json` fixture that had to be written by hand as a result.

Adding that endpoint to the dump means token UIDs would land in files people paste into bug reports, and a UID identifies a physical card somebody carries around. So the anonymizer learns about the token list in the same change: tokens are replaced with sequential stand-ins rather than redacted in place, keeping the shape useful as a fixture while losing everything identifying.

The two halves belong in one commit deliberately. Capturing the endpoint without the anonymizer would be a privacy regression in the tool built to prevent exactly that.

Also adds a `PeblarUnsupportedFirmwareVersionError` branch to the dump's REST API section. Since #441 that is what an older charger raises, and it was being reported as "Local REST API not enabled or not allowed", which is the wrong diagnosis for someone trying to work out why their dump is short.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Follows up on #441, which introduced the firmware guard this now reports on.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
