### PR TITLE
Report error and warning codes as integers

### DIFF
--- a/src/peblar/cli/__init__.py
+++ b/src/peblar/cli/__init__.py
@@ -2160,10 +2160,12 @@ async def system(
     table.add_column("Value", style="bold")
 
     table.add_row(
-        "Active error codes", ",".join(data.active_error_codes) or "No errors"
+        "Active error codes",
+        ", ".join(str(code) for code in data.active_error_codes) or "No errors",
     )
     table.add_row(
-        "Active warning codes", ",".join(data.active_warning_codes) or "No warnings"
+        "Active warning codes",
+        ", ".join(str(code) for code in data.active_warning_codes) or "No warnings",
     )
 
     table.add_section()

--- a/src/peblar/models.py
+++ b/src/peblar/models.py
@@ -825,10 +825,10 @@ class PeblarHealth(BaseModel):
 class PeblarSystem(BaseModel):
     """Object holding the system information of the Peblar charger."""
 
-    active_error_codes: list[str] = field(
+    active_error_codes: list[int] = field(
         metadata=field_options(alias="ActiveErrorCodes")
     )
-    active_warning_codes: list[str] = field(
+    active_warning_codes: list[int] = field(
         metadata=field_options(alias="ActiveWarningCodes")
     )
     cellular_signal_strength: int | None = field(

--- a/tests/cli/__snapshots__/test_cli.ambr
+++ b/tests/cli/__snapshots__/test_cli.ambr
@@ -447,6 +447,29 @@
   
   '''
 # ---
+# name: test_system_with_active_codes
+  '''
+                 Peblar charger system status               
+  ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┓
+  ┃ Property                      ┃ Value                  ┃
+  ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━┩
+  │ Active error codes            │ 10, 22                 │
+  │ Active warning codes          │ 5                      │
+  ├───────────────────────────────┼────────────────────────┤
+  │ Phase count                   │ 3                      │
+  │ Force of single phase allowed │ ✅                     │
+  ├───────────────────────────────┼────────────────────────┤
+  │ Firmware version              │ 1.9.0+1+WL-1           │
+  │ Product serial number         │ 00-00-AAA-000          │
+  │ Product part number           │ 0000-0000-0000         │
+  ├───────────────────────────────┼────────────────────────┤
+  │ Uptime                        │ 3514985 seconds        │
+  │ WLAN signal strength          │ WLAN not connected     │
+  │ Cellular signal strength      │ Cellular not connected │
+  └───────────────────────────────┴────────────────────────┘
+  
+  '''
+# ---
 # name: test_unsupported_firmware_error_handler
   '''
   ╭──────────────────────── Unsupported firmware version ────────────────────────╮

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -288,6 +288,22 @@ def test_system(
     assert output == snapshot
 
 
+def test_system_with_active_codes(
+    runner: CliRunner,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """System command lists the codes a faulted charger reports.
+
+    The codes are numbers, so they need converting before they can be
+    joined into a line of text.
+    """
+    system = PeblarSystem.from_json(load_fixture("system_faulted.json"))
+    mock_cls = _mock_peblar_with_api({"system": system}, login=None)
+    exit_code, output = _invoke(runner, ["system", *_AUTH], mock_cls)
+    assert exit_code == 0
+    assert output == snapshot
+
+
 # ---------------------------------------------------------------------------
 # --quiet / -q flag
 # ---------------------------------------------------------------------------

--- a/tests/fixtures/system_faulted.json
+++ b/tests/fixtures/system_faulted.json
@@ -1,0 +1,17 @@
+{
+  "ActiveErrorCodes": [
+    10,
+    22
+  ],
+  "ActiveWarningCodes": [
+    5
+  ],
+  "CellularSignalStrength": null,
+  "FirmwareVersion": "1.9.0+1+WL-1",
+  "Force1PhaseAllowed": true,
+  "PhaseCount": 3,
+  "ProductPn": "0000-0000-0000",
+  "ProductSn": "00-00-AAA-000",
+  "Uptime": 3514985,
+  "WlanSignalStrength": null
+}

--- a/tests/test_peblar.py
+++ b/tests/test_peblar.py
@@ -473,6 +473,23 @@ async def test_api_system() -> None:
             system = await api.system()
     assert system.uptime == 3514985
     assert system.phase_count == 3
+    assert system.active_error_codes == []
+    assert system.active_warning_codes == []
+
+
+async def test_api_system_error_codes_are_integers() -> None:
+    """Test the charger's error and warning codes stay numbers.
+
+    The API documents these as integer arrays. Typing them as strings
+    still parses, because the codes get stringified on the way in, which
+    is exactly the kind of silent damage a type is meant to prevent.
+    """
+    with aioresponses() as mocked:
+        mocked.get(API_SYSTEM_URL, status=200, body=load_fixture("system_faulted.json"))
+        async with PeblarApi(host=HOST, token="t") as api:
+            system = await api.system()
+    assert system.active_error_codes == [10, 22]
+    assert system.active_warning_codes == [5]
 
 
 async def test_api_ev_interface_read() -> None:


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Breaking: `PeblarSystem.active_error_codes` and `active_warning_codes` change from `list[str]` to `list[int]`.

The local REST API documents both as "An integer array with active error codes". They were typed as strings, and that parsed without complaint because the codes got stringified on the way in. A charger reporting `[10, 22]` handed back `['10', '22']`, which is exactly the kind of quiet damage a type annotation is supposed to prevent.

The `system` command in the CLI joined them straight into a line of text, which only worked because of that stringification. It converts explicitly now, and uses `", "` so a row with several codes stays readable.

Both existing fixtures have empty lists for these fields, so no test could observe the element type. A fixture with codes in it now pins the parsing and the rendering separately.

Checked against a real charger: it reports empty lists on a healthy unit, so the spec is the source here rather than observation.

On the impact for Home Assistant: none in the integration code. It only reads these through `bool(...)` in `binary_sensor.py`, which behaves the same either way. The diagnostics dump does include the raw values, so those change from `["10"]` to `[10]`, but only on a charger that actually has an active code.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
