### PR TITLE
Surface plain string error bodies

### DIFF
--- a/src/peblar/utils.py
+++ b/src/peblar/utils.py
@@ -15,19 +15,32 @@ def get_awesome_version(version: str) -> AwesomeVersion:
 def build_error_message(message: str, content: str) -> str:
     """Enrich an error message with the one the charger sent along.
 
-    Peblar wraps errors in a JSON object holding a `statusmsg` field. Not
-    every response follows that shape, so anything else is dropped and the
-    caller is left with just the generic message.
+    Peblar usually wraps errors in a JSON object holding a `statusmsg`
+    field, but not always: some endpoints answer with a bare JSON string,
+    and a few of those wrap it a second time. Anything that is not a
+    readable sentence in the end is dropped, leaving the generic message.
     """
     try:
         payload = orjson.loads(content)
     except orjson.JSONDecodeError:
         return message
 
-    if not isinstance(payload, dict):
-        return message
+    if isinstance(payload, dict):
+        reason = payload.get("statusmsg") or payload.get("StatusMsg")
+    else:
+        reason = payload
 
-    reason = payload.get("statusmsg") or payload.get("StatusMsg")
+    # Some endpoints hand back a JSON string that itself holds JSON, so
+    # peel until there is nothing left to decode.
+    while isinstance(reason, str):
+        try:
+            unwrapped = orjson.loads(reason)
+        except orjson.JSONDecodeError:
+            break
+        if not isinstance(unwrapped, str):
+            break
+        reason = unwrapped
+
     if not isinstance(reason, str) or not reason:
         return message
 

--- a/src/peblar/utils.py
+++ b/src/peblar/utils.py
@@ -36,9 +36,14 @@ def build_error_message(message: str, content: str) -> str:
         try:
             unwrapped = orjson.loads(reason)
         except orjson.JSONDecodeError:
+            # Not JSON any more, so this is the sentence itself.
             break
+
         if not isinstance(unwrapped, str):
-            break
+            # Structured data rather than a sentence. Handing back the text
+            # it was written as would put raw JSON in front of the user.
+            return message
+
         reason = unwrapped
 
     if not isinstance(reason, str) or not reason:

--- a/tests/test_peblar.py
+++ b/tests/test_peblar.py
@@ -1109,6 +1109,11 @@ async def test_authentication_error_includes_charger_message() -> None:
         ('"Nope"', "Boom: Nope"),
         ('""', "Boom"),
         ("42", "Boom"),
+        # A string holding anything but another string is structured data,
+        # not a sentence, so it is dropped rather than shown as raw text.
+        (r'"{\"statusmsg\":\"Nope\"}"', "Boom"),
+        ('"42"', "Boom"),
+        ('"null"', "Boom"),
         # And a few wrap that string a second time. This is what a charger
         # without PLC hardware answers on the autocharge endpoints.
         (

--- a/tests/test_peblar.py
+++ b/tests/test_peblar.py
@@ -1105,6 +1105,18 @@ async def test_authentication_error_includes_charger_message() -> None:
         ("[]", "Boom"),
         ("not json", "Boom"),
         ("", "Boom"),
+        # Some endpoints answer with a bare JSON string instead.
+        ('"Nope"', "Boom: Nope"),
+        ('""', "Boom"),
+        ("42", "Boom"),
+        # And a few wrap that string a second time. This is what a charger
+        # without PLC hardware answers on the autocharge endpoints.
+        (
+            r'"\"This endpoint is not available when PLC hardware is not present '
+            r'or enabled.\""',
+            "Boom: This endpoint is not available when PLC hardware is not "
+            "present or enabled.",
+        ),
     ],
 )
 def test_build_error_message(content: str, expected: str) -> None:


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Error bodies that are a plain JSON string were being thrown away, so the caller got the generic message and no idea why a call failed.

`build_error_message` only looked at a JSON object with a `statusmsg` field. Some endpoints answer with a bare JSON string instead, and a few wrap that string a second time.

Found against a real charger. The autocharge endpoints refuse a charger without PLC hardware, and they say exactly why:

```
POST /api/v1/config/auth/vehicle-standalonelist
403  "\"This endpoint is not available when PLC hardware is not present or enabled.\""
```

Before and after, for that response:

```
PeblarError: Error occurred while communicating to the Peblar charger
PeblarError: Error occurred while communicating to the Peblar charger: This endpoint is not available when PLC hardware is not present or enabled.
```

The unwrapping loop stops as soon as decoding no longer yields a string, so a number or an object nested inside never turns into an error message. The parametrized test covers the object form, the plain string, the doubly wrapped string, non-JSON, an empty string, an object without `statusmsg`, and a number.

Worth knowing for anyone using the autocharge methods: on a charger without PLC hardware, `GET` on the vehicle list answers `200 null`, while adding, deleting and `config/auth/vehicle-latest` all answer `403`. Only the list is served.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
