### PR TITLE
Take a datetime for the meter history time range

### DIFF
--- a/src/peblar/cli/__init__.py
+++ b/src/peblar/cli/__init__.py
@@ -156,37 +156,41 @@ def normalize_meterhistory_bound(
     value: str | None,
     *,
     is_stop: bool = False,
-) -> str | None:
-    """Convert a date-only meter history bound to UTC ISO format."""
-    if value is None or "T" in value:
-        return value
+) -> datetime | None:
+    """Read a meter history bound the way someone would type it.
 
+    A bare date covers the whole of that day, so a stop bound runs to its
+    last second rather than to midnight, which would drop the day itself.
+    """
+    if value is None:
+        return None
+
+    # Dates first: a full ISO parse would take a bare date too, and then
+    # a stop bound would land on midnight and drop the day itself.
     for fmt in ("%Y-%m-%d", "%d-%m-%Y"):
         try:
             bound = datetime.strptime(value, fmt)  # noqa: DTZ007
-            break
         except ValueError:
             continue
-    else:
-        return value
 
-    if is_stop:
-        bound = bound.replace(hour=23, minute=59, second=59)
+        if is_stop:
+            bound = bound.replace(hour=23, minute=59, second=59)
 
-    return bound.replace(tzinfo=UTC).isoformat().replace("+00:00", "Z")
+        return bound.replace(tzinfo=UTC)
+
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError:
+        msg = f"Could not read '{value}' as a date or timestamp"
+        raise typer.BadParameter(msg) from None
 
 
-def meterhistory_filename_part(value: str | None) -> str:
-    """Format a meter history bound value for use in filenames."""
+def meterhistory_filename_part(value: datetime | None) -> str:
+    """Format a meter history bound for use in filenames."""
     if value is None:
         return "all"
 
-    try:
-        dt = datetime.fromisoformat(value)
-    except ValueError:
-        return value.replace(":", "-").replace("T", "_")
-
-    return dt.strftime("%d-%m-%Y_%H-%M-%S")
+    return value.strftime("%d-%m-%Y_%H-%M-%S")
 
 
 def meterhistory_total_energy_mwh(history: PeblarMeterHistory) -> int:
@@ -210,7 +214,7 @@ async def meterhistory_fetch_data(
     *,
     start: str | None,
     stop: str | None,
-) -> tuple[str | None, str | None, PeblarMeterHistory, list[PeblarRfidToken]]:
+) -> tuple[datetime | None, datetime | None, PeblarMeterHistory, list[PeblarRfidToken]]:
     """Fetch and normalize data needed for meter history export."""
     normalized_start = normalize_meterhistory_bound(start)
     normalized_stop = normalize_meterhistory_bound(stop, is_stop=True)

--- a/src/peblar/models.py
+++ b/src/peblar/models.py
@@ -867,6 +867,14 @@ class PeblarMeterHistorySession(BaseModel):
         default=None,
         metadata=field_options(alias="AuthToken"),
     )
+    """Token the session was authorized with.
+
+    Matches PeblarRfidToken.rfid_token_uid, so it can be resolved to the
+    description someone gave the card. None when the charger is set to
+    charge without authentication, and on sessions that predate it being
+    turned on. Present as soon as the session starts, so there is no need
+    to wait for it to finish.
+    """
     checksum: int = field(metadata=field_options(alias="Checksum"))
     session_number: int = field(metadata=field_options(alias="SessionNumber"))
     session_start_energy_mwh: int = field(

--- a/src/peblar/peblar.py
+++ b/src/peblar/peblar.py
@@ -72,6 +72,7 @@ from .websocket import PeblarWebsocket
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Coroutine
+    from datetime import datetime
 
     from peblar.const import (
         AccessMode,
@@ -379,16 +380,25 @@ class Peblar:
     async def meter_history(
         self,
         *,
-        start: str | None = None,
-        stop: str | None = None,
+        start: datetime | None = None,
+        stop: datetime | None = None,
     ) -> PeblarMeterHistory:
-        """Get meter history in the requested time range."""
+        """Get meter history, optionally limited to a time range.
+
+        The charger reads these bounds as ISO 8601 and quietly ignores
+        anything it cannot parse: hand it a Unix timestamp and it returns
+        the whole history instead of an error. Taking datetimes is what
+        keeps that from happening.
+
+        A naive datetime is read as the charger's own local time. An aware
+        one carries its offset, which the charger does honour.
+        """
         url = URL("statistics/meterhistory")
         query: dict[str, str] = {}
         if start:
-            query["StartTime"] = start
+            query["StartTime"] = start.isoformat()
         if stop:
-            query["StopTime"] = stop
+            query["StopTime"] = stop.isoformat()
         if query:
             url = url.with_query(query)
 

--- a/src/peblar/websocket.py
+++ b/src/peblar/websocket.py
@@ -150,7 +150,18 @@ class PeblarWebsocket:
         *,
         topic: WebsocketTopic = WebsocketTopic.RFID_TOKEN_FOUND,
     ) -> None:
-        """Subscribe to tokens being presented to the charger."""
+        """Subscribe to a token being read for enrolment.
+
+        This is not how a charger announces who authorized a session. In
+        Peblar's own web interface the only thing subscribing to these
+        topics is the dialog that adds a token, where you hold a card
+        against the reader and it fills in the identifier for you.
+        Listening in on a charger going about its business produces
+        nothing, badged-in sessions included.
+
+        For the token a session was authorized with, read
+        PeblarMeterHistorySession.auth_token instead.
+        """
         await self.subscribe(
             topic,
             lambda data: callback(PeblarTokenFound.from_dict(data)),

--- a/tests/test_meterhistory.py
+++ b/tests/test_meterhistory.py
@@ -127,6 +127,29 @@ def test_a_bare_date_covers_the_whole_day() -> None:
 
 
 @pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("2026-08-30T12:00:00Z", "2026-08-30T12:00:00+00:00"),
+        ("2026-08-30T12:00:00+02:00", "2026-08-30T12:00:00+02:00"),
+        ("2026-08-30T12:00:00", "2026-08-30T12:00:00"),
+    ],
+)
+def test_the_iso_forms_the_charger_reads_come_through(
+    value: str, expected: str
+) -> None:
+    """Test the ways of writing a moment that a charger accepts are kept.
+
+    All three were tried against a charger and picked out the same
+    sessions: it reads the offset when there is one, and takes a bare
+    timestamp as its own local time.
+    """
+    bound = normalize_meterhistory_bound(value)
+
+    assert bound is not None
+    assert bound.isoformat() == expected
+
+
+@pytest.mark.parametrize(
     "value",
     [
         "1756555555",

--- a/tests/test_meterhistory.py
+++ b/tests/test_meterhistory.py
@@ -5,12 +5,15 @@ from __future__ import annotations
 import io
 import re
 from contextlib import redirect_stdout
+from datetime import UTC, datetime
 from pathlib import Path  # noqa: TC003
 
 import pytest
+import typer
 from aioresponses import aioresponses
 
-from peblar.cli import meterhistory
+from peblar import Peblar
+from peblar.cli import meterhistory, normalize_meterhistory_bound
 from tests import load_fixture
 
 HOST = "example.com"
@@ -107,3 +110,62 @@ async def test_meterhistory_export_writes_csv(
     text = out_file.read_text(encoding="utf-8")
     assert "12-34-Z56-P4R" in text
     assert "123456789A1234" in text
+
+
+def test_a_bare_date_covers_the_whole_day() -> None:
+    """Test a stop bound given as a date runs to the end of it.
+
+    Stopping at midnight would drop the day someone just asked for.
+    """
+    start = normalize_meterhistory_bound("2026-08-30")
+    stop = normalize_meterhistory_bound("2026-08-30", is_stop=True)
+
+    assert start is not None
+    assert stop is not None
+    assert start.isoformat() == "2026-08-30T00:00:00+00:00"
+    assert stop.isoformat() == "2026-08-30T23:59:59+00:00"
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "1756555555",
+        "yesterday",
+        "30/08/2026",
+    ],
+)
+def test_a_bound_the_charger_would_ignore_is_refused(value: str) -> None:
+    """Test a bound that is not a time is turned away here.
+
+    The charger reads these as ISO 8601 and quietly hands back its entire
+    history for anything else, a Unix timestamp included, so passing one
+    on would answer a question nobody asked.
+    """
+    with pytest.raises(typer.BadParameter):
+        normalize_meterhistory_bound(value)
+
+
+@pytest.mark.asyncio
+async def test_the_time_range_reaches_the_charger_as_iso() -> None:
+    """Test the bounds are handed over in the one format the charger reads.
+
+    The mock is registered on the exact URL, so it only answers if the
+    query was built that way: anything else fails to match.
+    """
+    with aioresponses() as mocked:
+        mocked.post(LOGIN_URL, status=200, body="", content_type="text/plain")
+        mocked.get(
+            f"{METERHISTORY_URL}?StartTime=2026-08-29T06:00:00%2B00:00"
+            "&StopTime=2026-08-30T18:30:00%2B00:00",
+            status=200,
+            body=load_fixture("meterhistory.json"),
+        )
+
+        async with Peblar(host=HOST) as peblar:
+            await peblar.login(password="secret")
+            history = await peblar.meter_history(
+                start=datetime(2026, 8, 29, 6, 0, tzinfo=UTC),
+                stop=datetime(2026, 8, 30, 18, 30, tzinfo=UTC),
+            )
+
+    assert history.session


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

`meter_history()` took its bounds as `str` and handed them to the charger untouched. The charger reads them as ISO 8601 and quietly ignores anything else, so a Unix timestamp came back as the entire history rather than an error. Measured against a real charger: a Unix timestamp returned all 322 sessions and 77 KB, the same ISO moment returned 5 sessions and 4 KB, and passing Unix values for both bounds returned nothing at all. Every one of those is a silently wrong answer.

It now takes `datetime` and formats the bounds itself. A naive datetime is read as the charger's own local time, an aware one carries its offset, and the charger honours both. This is a breaking change to a public method, which is worth taking now: the CLI was the only caller in the tree, and the Home Assistant integration is about to start using this.

The knowledge that the charger wants ISO lived in the CLI, in `normalize_meterhistory_bound`. That has moved down to where it belongs, and the CLI helper now returns a `datetime`. It also refuses a bound that is neither a date nor a timestamp instead of passing it along, since passing it along is exactly what produced the wrong answer above. Dates are tried before a full ISO parse, because `fromisoformat` accepts a bare date too, and a stop bound would then land on midnight and drop the day someone just asked for.

Two docstrings were wrong or missing, both about the same feature. `subscribe_token_found()` said it subscribes to "tokens being presented to the charger", which reads like a charger announcing who just badged in. It does not do that. Listening on both token topics across roughly twenty minutes of a real charger going about its business, covering an idle charger, a full unplug and replug with authorization required, and an active charging session, produced no events at all. In Peblar's own web interface the only thing subscribing to these topics is the dialog that adds a token, where you hold a card against the reader and it fills in the identifier for you. The docstring now says so, and points at `PeblarMeterHistorySession.auth_token` for the token a session was actually authorized with.

That field had no documentation. It matches `PeblarRfidToken.rfid_token_uid`, so it resolves to the description someone gave the card, it is `None` when the charger charges without authentication, and it is filled in as soon as the session starts rather than when it ends.

Three mutations were used to check the tests bite: dropping the ISO formatting, dropping the end-of-day handling for a stop date, and letting an unreadable bound through. Each one fails a test. The lines this touches in `meter_history()` had no coverage at all before.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

The token findings came out of https://github.com/orgs/home-assistant/discussions/3520, where a user works around the missing session token by polling the meter history from a shell script.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
